### PR TITLE
chore(styling): prevent header sub tabs from covering header content on mobile (#111)

### DIFF
--- a/src/components/common/HeaderSubTabs.tsx
+++ b/src/components/common/HeaderSubTabs.tsx
@@ -16,10 +16,6 @@ const PositionController = styled.div`
     right: 190px;
     transform: none;
   }
-  @media (max-width: ${deviceWidth.mobile}px) {
-    left: 55%;
-    top: 2.7rem;
-  }
 `
 
 export interface Props {

--- a/src/components/common/HeaderSubTabs.tsx
+++ b/src/components/common/HeaderSubTabs.tsx
@@ -16,6 +16,10 @@ const PositionController = styled.div`
     right: 190px;
     transform: none;
   }
+  @media (max-width: ${deviceWidth.mobile}px) {
+    left: 55%;
+    top: 2.7rem;
+  }
 `
 
 export interface Props {

--- a/src/components/projects/ProjectsHero.tsx
+++ b/src/components/projects/ProjectsHero.tsx
@@ -16,6 +16,9 @@ const ContainerInner = styled.div`
   > div {
     transition: transform 0.3s ease;
   }
+  @media (max-width: ${deviceWidth.mobile}px) {
+    padding-top: 16%;
+  }
 `
 
 const StatisticContainer = styled.div`


### PR DESCRIPTION
## Scope
Fix mobile responsive tabs that are covering the header content

## Work done
Added media query for HeaderSubTabs to adjust for mobile devices

## Test
Select any mobile device screen view in browser

## Screenshot
# Before
![image](https://user-images.githubusercontent.com/35291291/77905748-1c597e80-7287-11ea-9bfe-35d94b1485f8.png)

# After
![image](https://user-images.githubusercontent.com/35291291/77919896-099e7400-729e-11ea-9e86-9c37f9dcb485.png)

