### PR TITLE
chore(style): fix date filter dropdown alignment

### DIFF
--- a/src/common/components/Filters/Filters.styles.ts
+++ b/src/common/components/Filters/Filters.styles.ts
@@ -313,9 +313,9 @@ export const DatePickerModal = styled.div`
   border-radius: 4px;
   height: 442px;
   width: 619px;
-  top: 50%;
+  top: 100%;
   left: 50%;
-  transform: translate(-50%, 6%);
+  transform: translate(-50%);
   z-index: 3;
   :after {
     content: '';


### PR DESCRIPTION
## Scope
https://nonaredteam.atlassian.net/browse/IXO-503

## Work Done
Updated the alignment so that it is the same as the rest of the dropdowns

## Steps to Test
Run the app and make sure the filters align which each other

## Screenshots
This screenshot serves to indicate the alignment it is not a normal app state
![image](https://user-images.githubusercontent.com/46312800/82059374-3b409280-96c6-11ea-8b3b-5347f7181b59.png)

