### PR TITLE
fix: scroll issue on mobile dropdowns

### DIFF
--- a/src/modules/Entities/components/EntitiesFilter/EntitiesFilter.tsx
+++ b/src/modules/Entities/components/EntitiesFilter/EntitiesFilter.tsx
@@ -75,7 +75,7 @@ class EntitiesFilter extends React.Component<Props, State> {
   }
 
   toggleMobileFilterMenuShow = (menu: string): void => {
-    if (this.state.mobileFilterActiveMenu === 'menu') {
+    if (this.state.mobileFilterActiveMenu !== '') {
       document.querySelector('body').classList.remove('noScroll')
     } else {
       document.querySelector('body').classList.add('noScroll')


### PR DESCRIPTION
## Scope
https://nonaredteam.atlassian.net/browse/IXO-539

## Work Done
Fixed bug that was causing scroll to break when opening the filter dropdowns on mobile

## Steps to Test
On mobile - Check that you can interact with the filters and still scroll afterwards
