### PR TITLE
chore: adjust mobile tabs spacing

### DIFF
--- a/src/common/components/Header/HeaderLeft/HeaderLeft.styles.ts
+++ b/src/common/components/Header/HeaderLeft/HeaderLeft.styles.ts
@@ -93,6 +93,10 @@ export const Main = styled.div`
   padding: 15px 20px;
   justify-content: flex-end;
 
+  @media (max-width: ${deviceWidth.tablet}px) {
+    padding: 15px 20px 30px;
+  }
+
   @media (min-width: ${deviceWidth.tablet}px) {
     justify-content: flex-start;
   }

--- a/src/common/components/HeaderTabs/HeaderTabs.styles.ts
+++ b/src/common/components/HeaderTabs/HeaderTabs.styles.ts
@@ -5,11 +5,12 @@ export const PositionController = styled.div`
   position: fixed;
   z-index: 9;
   left: 50%;
-  top: 3.5rem;
-  transform: translateX(-50%);
-  @media (min-width: ${deviceWidth.desktop}px) {
+  top: 79px;
+  transform: translate(-50%, -50%);
+  @media (min-width: ${deviceWidth.tablet}px) {
     left: initial;
     right: 190px;
+    top: 3.5rem;
     transform: none;
   }
 `


### PR DESCRIPTION
## Scope
https://nonaredteam.atlassian.net/browse/IXO-575

## Work Done
Add spacing in the header to align the tabs on
Aligned the tabs halfway onto the header on mobile

## Steps to Test
Make sure the tabs are centered vertically on mobile

## Screenshots
![image](https://user-images.githubusercontent.com/46312800/82808216-d46f6600-9e89-11ea-9567-d585f1e18511.png)
