### PR TITLE
chore: adjust positioning to cover hero elements fully

### DIFF
--- a/src/common/components/ControlPanel/ControlPanel.styles.ts
+++ b/src/common/components/ControlPanel/ControlPanel.styles.ts
@@ -62,7 +62,7 @@ export const ControlPanelScrollWrapper = styled.div`
     }
     &.fixed {
       position: absolute;
-      top: -170px;
+      top: -190px;
       z-index: 99;
     }
   }


### PR DESCRIPTION
## Scope
Fix the header elements that are displaying above the order summary

## Work Done
Adjust the fuel entity bot and order summary positioning to the cover hero elements fully
