### PR TITLE
Changed treasury/MsgSend keys from camelCase to snake_case.

### DIFF
--- a/src/modules/FuelEntity/FuelEntity.actions.ts
+++ b/src/modules/FuelEntity/FuelEntity.actions.ts
@@ -55,8 +55,8 @@ export const confirmOrder = (entityDid: string) => (
 
     const tx: FuelEntityOrderTx = {
       pubKey,
-      fromDid: userDid,
-      toDidOrAddr: `${projectAddr}`,
+      from_did: userDid,
+      to_did: `${projectAddr}`,
       amount: [{ denom: 'ixo', amount }],
     }
 

--- a/src/modules/FuelEntity/types.ts
+++ b/src/modules/FuelEntity/types.ts
@@ -18,8 +18,8 @@ export interface FuelEntityState {
 
 export interface FuelEntityOrderTx {
   pubKey: string
-  fromDid: string
-  toDidOrAddr: string
+  from_did: string
+  to_did: string
   amount: [
     {
       denom: string


### PR DESCRIPTION
`toDidOrAddr` was changed to `to_did` intentionally. On the blockchain side, this is still `to_did`. Eventually it will be changed to `to_did_or_addr`.