### PR TITLE
fix(style): overlap of div border and icon button list

### DIFF
--- a/src/common/components/Filters/Filters.styles.ts
+++ b/src/common/components/Filters/Filters.styles.ts
@@ -104,6 +104,7 @@ export const ModalItems = styled.div`
   display: flex;
   overflow-y: auto;
   flex-flow: row wrap;
+  margin-bottom: 3.5rem;
   @media (min-width: ${deviceWidth.tablet}px) {
     max-height: 380px;
   }
@@ -356,7 +357,6 @@ export const DoneButtonWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-top: 3.5rem;
 `
 
 export const MobileDatePicker = styled.div`

--- a/src/common/components/Filters/Filters.styles.ts
+++ b/src/common/components/Filters/Filters.styles.ts
@@ -356,6 +356,7 @@ export const DoneButtonWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-top: 3.5rem;
 `
 
 export const MobileDatePicker = styled.div`
@@ -617,7 +618,7 @@ export const DoneButton = styled.button`
   outline: none !important;
   -webkit-appearance: none;
   -moz-appearance: none;
-  margin-top: 1.25rem;
+  margin-bottom: 1rem;
   &:after {
     content: '';
     position: absolute;

--- a/src/common/components/Header/HeaderLeft/HeaderLeft.tsx
+++ b/src/common/components/Header/HeaderLeft/HeaderLeft.tsx
@@ -1,8 +1,8 @@
-import * as React from "react";
-import { Fragment } from "react";
-import { deviceWidth } from "../../../../lib/commonData";
-import MediaQuery from "react-responsive";
-import { getIxoWorldRoute } from "../../../utils/formatters";
+import * as React from 'react'
+import { Fragment } from 'react'
+import { deviceWidth } from '../../../../lib/commonData'
+import MediaQuery from 'react-responsive'
+import { getIxoWorldRoute } from '../../../utils/formatters'
 import {
   Burger,
   Main,
@@ -15,12 +15,12 @@ import {
   MobileMenu,
   NavItems,
   HeaderAnchor,
-} from "./HeaderLeft.styles";
+} from './HeaderLeft.styles'
 
 export interface ParentProps {
-  currentEntity: string | undefined;
-  openMenu: boolean;
-  handleBurgerClick: any;
+  currentEntity: string | undefined
+  openMenu: boolean
+  handleBurgerClick: any
 }
 
 export class HeaderLeft extends React.Component<ParentProps> {
@@ -39,13 +39,13 @@ export class HeaderLeft extends React.Component<ParentProps> {
           </HeaderAnchor>
           <HeaderAnchor
             target="_blank"
-            href={getIxoWorldRoute("/getixowallet/deliver")}
+            href={getIxoWorldRoute('/getixowallet/deliver')}
           >
             Deliver
           </HeaderAnchor>
           <HeaderAnchor
             target="_blank"
-            href={getIxoWorldRoute("/getixowallet/invest")}
+            href={getIxoWorldRoute('/getixowallet/invest')}
           >
             Invest
           </HeaderAnchor>
@@ -53,24 +53,34 @@ export class HeaderLeft extends React.Component<ParentProps> {
             Learn
           </HeaderAnchor>
         </Fragment>
-      );
+      )
     } else {
       return (
         <Fragment>
           <MenuHeaderContainer>
-            <MenuHeaderLink className="first-mobile" exact={true} to="/">
+            <MenuHeaderLink
+              className="first-mobile"
+              exact={true}
+              to="/"
+              onClick={this.props.handleBurgerClick}
+            >
               Explore
             </MenuHeaderLink>
           </MenuHeaderContainer>
           <MenuHeaderContainer>
-            <MenuHeaderAnchor target="_blank" href="https://build.ixo.world/">
+            <MenuHeaderAnchor
+              target="_blank"
+              href="https://build.ixo.world/"
+              onClick={this.props.handleBurgerClick}
+            >
               Build
             </MenuHeaderAnchor>
           </MenuHeaderContainer>
           <MenuHeaderContainer>
             <MenuHeaderAnchor
               target="_blank"
-              href={getIxoWorldRoute("/getixowallet/deliver")}
+              href={getIxoWorldRoute('/getixowallet/deliver')}
+              onClick={this.props.handleBurgerClick}
             >
               Deliver
             </MenuHeaderAnchor>
@@ -78,36 +88,41 @@ export class HeaderLeft extends React.Component<ParentProps> {
           <MenuHeaderContainer>
             <MenuHeaderAnchor
               target="_blank"
-              href={getIxoWorldRoute("/getixowallet/invest")}
+              href={getIxoWorldRoute('/getixowallet/invest')}
+              onClick={this.props.handleBurgerClick}
             >
               Invest
             </MenuHeaderAnchor>
           </MenuHeaderContainer>
           <MenuHeaderContainer>
-            <MenuHeaderAnchor target="_blank" href="https://docs.ixo.world/">
+            <MenuHeaderAnchor
+              target="_blank"
+              href="https://docs.ixo.world/"
+              onClick={this.props.handleBurgerClick}
+            >
               Learn
             </MenuHeaderAnchor>
           </MenuHeaderContainer>
         </Fragment>
-      );
+      )
     }
-  };
+  }
 
   render(): JSX.Element {
     return (
       <Fragment>
         <Main className="col-md-12 col-lg-8 d-flex align-items-center">
           <div>
-            <a href={getIxoWorldRoute("")}>
+            <a href={getIxoWorldRoute('')}>
               <IXOLogo
                 alt="IXO Logo"
-                src={require("../../../../assets/images/ixo-logo.svg")}
+                src={require('../../../../assets/images/ixo-logo.svg')}
               />
             </a>
           </div>
           <NavItems>
             <Burger onClick={this.props.handleBurgerClick}>
-              <div className={this.props.openMenu === true ? "change" : ""}>
+              <div className={this.props.openMenu === true ? 'change' : ''}>
                 <div className="bar1" />
                 <div className="bar2" />
                 <div className="bar3" />
@@ -118,14 +133,14 @@ export class HeaderLeft extends React.Component<ParentProps> {
             </MediaQuery>
           </NavItems>
         </Main>
-        <MediaQuery maxWidth={"991px"}>
+        <MediaQuery maxWidth={'991px'}>
           <MobileMenu
-            className={this.props.openMenu === true ? "openMenu" : ""}
+            className={this.props.openMenu === true ? 'openMenu' : ''}
           >
             {this.getMenuItems(false)}
           </MobileMenu>
         </MediaQuery>
       </Fragment>
-    );
+    )
   }
 }


### PR DESCRIPTION
## Scope
https://nonaredteam.atlassian.net/browse/IXO-895
https://nonaredteam.atlassian.net/browse/IXO-896

## Work Done
Fixed outline caused by overlap of button wrapper and icon button tag
Mobile burger menu now closes onClick

## Steps to Test
Verify filters are visible and there is no overlap and use mobile burger menu to test that menu closes

## Screenshots
- Chrome
![image](https://user-images.githubusercontent.com/35291291/91318688-cba96b80-e7bb-11ea-8a4c-e74c75cffd22.png)

- Safari
![Screenshot 2020-08-26 at 16 47 41](https://user-images.githubusercontent.com/35291291/91318738-de23a500-e7bb-11ea-9fda-3422d91d08cc.png)
