### PR TITLE
fix: template modal width

### DIFF
--- a/src/common/components/EntitySelector/EntitySelector.styles.ts
+++ b/src/common/components/EntitySelector/EntitySelector.styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { deviceWidth } from '../../../lib/commonData'
 
 export const ListWrapper = styled.div`
   max-height: 500px;
@@ -17,5 +18,21 @@ export const NoTemplatePreviewWrapper = styled.div`
 
   > div {
     margin-top: 10px;
+  }
+`
+export const ModalWrapper = styled.div`
+  > div {
+    top: 55%;
+    min-width: 270px;
+    left: -25%;
+    right: -15%;
+    @media (min-width: ${deviceWidth.mobileSmall}px) {
+      min-width: 300px;
+      left: -15%;
+    }
+    @media (min-width: ${deviceWidth.desktop}px) {
+      left: 0;
+      right: -100%;
+    }
   }
 `

--- a/src/common/components/EntitySelector/EntitySelector.tsx
+++ b/src/common/components/EntitySelector/EntitySelector.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import Modal from '../Modal/Modal'
 import { Entity } from './types'
 import TemplateClipboard from 'assets/icons/TemplateClipboard'
-import { NoTemplatePreviewWrapper, ListWrapper } from './EntitySelector.styles'
+import {
+  NoTemplatePreviewWrapper,
+  ListWrapper,
+  ModalWrapper,
+} from './EntitySelector.styles'
 import EntityCard from './EntityCard/EntityCard'
 import { LinkButton } from '../JsonForm/JsonForm.styles'
 
@@ -27,7 +31,7 @@ class EntitySelector extends React.Component<Props, State> {
     }
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentWillReceiveProps(nextProps: Props): void {
     const { selectedEntityId } = this.props
 
     if (selectedEntityId !== nextProps.selectedEntityId) {
@@ -35,25 +39,25 @@ class EntitySelector extends React.Component<Props, State> {
     }
   }
 
-  openTemplateSelector = () => {
+  openTemplateSelector = (): void => {
     this.setState({ isModalOpen: true })
   }
 
-  closeTemplateSelector = () => {
+  closeTemplateSelector = (): void => {
     this.setState({ isModalOpen: false })
   }
 
-  selectEntity = (selectedEntityId: string) => {
+  selectEntity = (selectedEntityId: string): void => {
     this.setState({ selectedEntityId })
   }
 
-  onSubmit = () => {
+  onSubmit = (): void => {
     this.setState({ isModalOpen: false })
     const { onSelectEntity } = this.props
     onSelectEntity(this.state.selectedEntityId)
   }
 
-  renderEntities = () => {
+  renderEntities = (): JSX.Element[] => {
     const NUMBER_OF_ROWS = 3
     const { entities } = this.props
     const { selectedEntityId } = this.state
@@ -61,6 +65,7 @@ class EntitySelector extends React.Component<Props, State> {
 
     return Array.from(Array(rowCount).keys()).map((rowIndex) => {
       return (
+        // eslint-disable-next-line react/jsx-key
         <div className="row">
           {entities
             .filter(
@@ -73,7 +78,7 @@ class EntitySelector extends React.Component<Props, State> {
                 <div
                   key={entity.did}
                   className={`col-md-${12 / NUMBER_OF_ROWS} text-left`}
-                  onClick={() => this.selectEntity(entity.did)}
+                  onClick={(): void => this.selectEntity(entity.did)}
                 >
                   <EntityCard
                     showImage={true}
@@ -88,7 +93,7 @@ class EntitySelector extends React.Component<Props, State> {
     })
   }
 
-  renderPreview = () => {
+  renderPreview = (): JSX.Element => {
     const { selectedEntityId, entities } = this.props
 
     if (!selectedEntityId) {
@@ -116,22 +121,23 @@ class EntitySelector extends React.Component<Props, State> {
     )
   }
 
-  render() {
+  render(): JSX.Element {
     const { isModalOpen } = this.state
 
     return (
       <>
         {this.renderPreview()}
         {isModalOpen && (
-          <Modal
-            submitText="Select"
-            cancelText="Cancel"
-            onCancel={this.closeTemplateSelector}
-            onSubmit={this.onSubmit}
-            style={{ right: '-100%' }}
-          >
-            <ListWrapper>{this.renderEntities()}</ListWrapper>
-          </Modal>
+          <ModalWrapper>
+            <Modal
+              submitText="Select"
+              cancelText="Cancel"
+              onCancel={this.closeTemplateSelector}
+              onSubmit={this.onSubmit}
+            >
+              <ListWrapper>{this.renderEntities()}</ListWrapper>
+            </Modal>
+          </ModalWrapper>
         )}
       </>
     )


### PR DESCRIPTION
## Scope
https://nonaredteam.atlassian.net/browse/IXO-894

## Work Done
Added modal wrapper and breakpoints to prevent modal from taking up space beyond container

## Steps to Test
View on different size screens

## Screenshots
- Mobile
<img width="253" alt="Screenshot 2020-09-03 at 11 06 59" src="https://user-images.githubusercontent.com/35291291/92095225-aaf19f00-edd5-11ea-81b2-cc5b84f33697.png">

- Desktop
<img width="1080" alt="Screenshot 2020-09-03 at 11 07 17" src="https://user-images.githubusercontent.com/35291291/92095247-b0e78000-edd5-11ea-88fd-9e423fb92677.png">
