### PR TITLE
Chart on entity detail page keeps reloading on icognitor

### DIFF
--- a/src/modules/Account/Account.actions.ts
+++ b/src/modules/Account/Account.actions.ts
@@ -59,7 +59,10 @@ export const updateLoginStatus = () => (
   } = getState()
 
   if (!keysafe) {
-    return dispatch(logout())
+    if (userInfo !== null) {
+      return dispatch(logout())
+    }
+    return
   }
 
   keysafe.getInfo((error, response) => {


### PR DESCRIPTION
## Scope

## Work Done
The issue was because when there is not keysafe extension installed, it kept user logging out the platform
The issue was because when user did not sign in the platform, it kept user logging out the platform
## Steps to Test

## Screenshots
