### PR TITLE
Move development deps under proper category

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1594,7 +1594,8 @@
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
-      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
+      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==",
+      "dev": true
     },
     "@stomp/stompjs": {
       "version": "5.4.4",
@@ -1751,6 +1752,7 @@
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.16.0.tgz",
       "integrity": "sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.4",
         "@sheerun/mutationobserver-shim": "^0.3.2",
@@ -1765,6 +1767,7 @@
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
           "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
@@ -1773,9 +1776,10 @@
           }
         },
         "@types/yargs": {
-          "version": "15.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "version": "15.0.9",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+          "integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
+          "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -1783,14 +1787,15 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -1798,6 +1803,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -1807,6 +1813,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -1814,17 +1821,20 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "pretty-format": {
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
           "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
           "requires": {
             "@jest/types": "^25.5.0",
             "ansi-regex": "^5.0.0",
@@ -1833,9 +1843,10 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -1846,6 +1857,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz",
       "integrity": "sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.5.1",
         "chalk": "^2.4.1",
@@ -1859,19 +1871,21 @@
       }
     },
     "@testing-library/react": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.5.0.tgz",
-      "integrity": "sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.3.2.tgz",
+      "integrity": "sha512-J6ftWtm218tOLS175MF9eWCxGp+X+cUXCpkPIin8KAXWtyZbr9CbqJ8M8QNd6spZxJDAGlw+leLG4MJWLlqVgg==",
+      "dev": true,
       "requires": {
-        "@babel/runtime": "^7.8.4",
-        "@testing-library/dom": "^6.15.0",
-        "@types/testing-library__react": "^9.1.2"
+        "@babel/runtime": "^7.6.0",
+        "@testing-library/dom": "^6.3.0",
+        "@types/testing-library__react": "^9.1.0"
       }
     },
     "@testing-library/user-event": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-7.2.1.tgz",
-      "integrity": "sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA=="
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-7.1.2.tgz",
+      "integrity": "sha512-lDyCVxxgX5lrgCa75ELCfWcdEDyfisjqoDIM3YsghQ+lyViIac/qT67qabQ/HmoVxyikFKovjKwWdn3b/oKhZA==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.9",
@@ -2094,6 +2108,7 @@
       "version": "16.9.8",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.8.tgz",
       "integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -2162,6 +2177,7 @@
       "version": "3.0.21",
       "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-3.0.21.tgz",
       "integrity": "sha512-jVtukxaARMQCJC74ikGzpxrzxDFPkcGEwLsFIsc/bAn2rcBUlJ0WgP71ShUc/Q0nnk4ClZn2jBm2tbh6HtxB3A==",
+      "dev": true,
       "requires": {
         "@types/react": "*",
         "@types/react-dom": "*",
@@ -2207,6 +2223,7 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz",
       "integrity": "sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==",
+      "dev": true,
       "requires": {
         "pretty-format": "^24.3.0"
       }
@@ -2215,6 +2232,7 @@
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.3.tgz",
       "integrity": "sha512-iCdNPKU3IsYwRK9JieSYAiX0+aYDXOGAmrC/3/M7AqqSDKnWWVv07X+Zk1uFSL7cMTUYzv4lQRfohucEocn5/w==",
+      "dev": true,
       "requires": {
         "@types/react-dom": "*",
         "@types/testing-library__dom": "*",
@@ -2225,6 +2243,7 @@
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
           "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
@@ -2233,9 +2252,10 @@
           }
         },
         "@types/yargs": {
-          "version": "15.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "version": "15.0.9",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+          "integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
+          "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -2243,14 +2263,15 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -2258,6 +2279,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -2267,6 +2289,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -2274,17 +2297,20 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "pretty-format": {
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
           "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
           "requires": {
             "@jest/types": "^25.5.0",
             "ansi-regex": "^5.0.0",
@@ -2293,9 +2319,10 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -2558,7 +2585,8 @@
     "@zeit/schemas": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.6.0.tgz",
-      "integrity": "sha512-uUrgZ8AxS+Lio0fZKAipJjAh415JyrOZowliZAzmnJSsf7piVL5w+G0+gFJ0KSu3QRhvui/7zuvpLz03YjXAhg=="
+      "integrity": "sha512-uUrgZ8AxS+Lio0fZKAipJjAh415JyrOZowliZAzmnJSsf7piVL5w+G0+gFJ0KSu3QRhvui/7zuvpLz03YjXAhg==",
+      "dev": true
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -2731,6 +2759,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
       "requires": {
         "string-width": "^2.0.0"
       },
@@ -2738,17 +2767,20 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -2758,6 +2790,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -2830,9 +2863,10 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "arch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
-      "integrity": "sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true
     },
     "are-we-there-yet": {
       "version": "1.1.5",
@@ -2880,7 +2914,8 @@
     "arg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arg/-/arg-2.0.0.tgz",
-      "integrity": "sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w=="
+      "integrity": "sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -2894,6 +2929,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
       "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.10.2",
         "@babel/runtime-corejs3": "^7.10.2"
@@ -3828,6 +3864,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "dev": true,
       "requires": {
         "ansi-align": "^2.0.0",
         "camelcase": "^4.0.0",
@@ -3841,22 +3878,26 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -3866,6 +3907,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -4436,7 +4478,8 @@
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -4455,6 +4498,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
       "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
+      "dev": true,
       "requires": {
         "arch": "^2.1.0",
         "execa": "^0.8.0"
@@ -4464,6 +4508,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -4474,6 +4519,7 @@
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
           "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -4487,7 +4533,8 @@
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
         }
       }
     },
@@ -5191,7 +5238,8 @@
     "css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
     },
     "cssdb": {
       "version": "4.4.0",
@@ -5727,7 +5775,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -5991,7 +6040,8 @@
     "dom-accessibility-api": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz",
-      "integrity": "sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA=="
+      "integrity": "sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -7506,6 +7556,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
       "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "dev": true,
       "requires": {
         "punycode": "^1.3.2"
       },
@@ -7513,7 +7564,8 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         }
       }
     },
@@ -10741,7 +10793,8 @@
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
     },
     "mini-create-react-context": {
       "version": "0.4.0",
@@ -11302,6 +11355,7 @@
       "version": "6.14.8",
       "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.8.tgz",
       "integrity": "sha512-HBZVBMYs5blsj94GTeQZel7s9odVuuSUHy1+AlZh7rPVux1os2ashvEGLy/STNK7vUjbrCg5Kq9/GXisJgdf6A==",
+      "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -11431,6 +11485,7 @@
         "JSONStream": {
           "version": "1.3.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "jsonparse": "^1.2.0",
             "through": ">=2.2.7 <3"
@@ -11438,11 +11493,13 @@
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "agent-base": {
           "version": "4.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "es6-promisify": "^5.0.0"
           }
@@ -11450,6 +11507,7 @@
         "agentkeepalive": {
           "version": "3.5.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "humanize-ms": "^1.2.1"
           }
@@ -11457,6 +11515,7 @@
         "ajv": {
           "version": "5.5.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "co": "^4.6.0",
             "fast-deep-equal": "^1.0.0",
@@ -11467,40 +11526,48 @@
         "ansi-align": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "^2.0.0"
           }
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aproba": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -11509,6 +11576,7 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -11522,6 +11590,7 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -11530,38 +11599,46 @@
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "asn1": {
           "version": "0.2.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safer-buffer": "~2.1.0"
           }
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aws4": {
           "version": "1.8.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "tweetnacl": "^0.14.3"
@@ -11570,6 +11647,7 @@
         "bin-links": {
           "version": "1.1.8",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
             "cmd-shim": "^3.0.0",
@@ -11581,11 +11659,13 @@
         },
         "bluebird": {
           "version": "3.5.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "boxen": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-align": "^2.0.0",
             "camelcase": "^4.0.0",
@@ -11599,6 +11679,7 @@
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11606,23 +11687,28 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "builtins": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "byline": {
           "version": "5.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "byte-size": {
           "version": "5.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cacache": {
           "version": "12.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bluebird": "^3.5.5",
             "chownr": "^1.1.1",
@@ -11643,23 +11729,28 @@
         },
         "call-limit": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "chalk": {
           "version": "2.4.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -11668,26 +11759,31 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ci-info": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cidr-regex": {
           "version": "2.0.10",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ip-regex": "^2.1.0"
           }
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cli-columns": {
           "version": "3.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "^2.0.0",
             "strip-ansi": "^3.0.1"
@@ -11696,6 +11792,7 @@
         "cli-table3": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "colors": "^1.1.2",
             "object-assign": "^4.1.0",
@@ -11705,6 +11802,7 @@
         "cliui": {
           "version": "5.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "^3.1.0",
             "strip-ansi": "^5.2.0",
@@ -11713,15 +11811,18 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "string-width": {
               "version": "3.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "emoji-regex": "^7.0.1",
                 "is-fullwidth-code-point": "^2.0.0",
@@ -11731,6 +11832,7 @@
             "strip-ansi": {
               "version": "5.2.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "^4.1.0"
               }
@@ -11739,11 +11841,13 @@
         },
         "clone": {
           "version": "1.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cmd-shim": {
           "version": "3.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "mkdirp": "~0.5.0"
@@ -11751,31 +11855,37 @@
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "color-convert": {
           "version": "1.9.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "color-name": "^1.1.1"
           }
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "colors": {
           "version": "1.3.3",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "strip-ansi": "^3.0.0",
             "wcwidth": "^1.0.0"
@@ -11784,17 +11894,20 @@
         "combined-stream": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "concat-stream": {
           "version": "1.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
@@ -11805,6 +11918,7 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -11818,6 +11932,7 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -11827,6 +11942,7 @@
         "config-chain": {
           "version": "1.1.12",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ini": "^1.3.4",
             "proto-list": "~1.2.1"
@@ -11835,6 +11951,7 @@
         "configstore": {
           "version": "3.1.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "dot-prop": "^4.2.1",
             "graceful-fs": "^4.1.2",
@@ -11846,11 +11963,13 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^1.1.1",
             "fs-write-stream-atomic": "^1.0.8",
@@ -11862,21 +11981,25 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "create-error-class": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "capture-stack-trace": "^1.0.0"
           }
@@ -11884,6 +12007,7 @@
         "cross-spawn": {
           "version": "5.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -11893,6 +12017,7 @@
             "lru-cache": {
               "version": "4.1.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -11900,21 +12025,25 @@
             },
             "yallist": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cyclist": {
           "version": "0.2.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
@@ -11922,35 +12051,42 @@
         "debug": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           },
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "defaults": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "clone": "^1.0.2"
           }
@@ -11958,29 +12094,35 @@
         "define-properties": {
           "version": "1.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "detect-newline": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "asap": "^2.0.0",
             "wrappy": "1"
@@ -11989,21 +12131,25 @@
         "dot-prop": {
           "version": "4.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
           }
         },
         "dotenv": {
           "version": "5.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "duplexify": {
           "version": "3.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "end-of-stream": "^1.0.0",
             "inherits": "^2.0.1",
@@ -12014,6 +12160,7 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -12027,6 +12174,7 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -12036,6 +12184,7 @@
         "ecc-jsbn": {
           "version": "0.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "jsbn": "~0.1.0",
@@ -12044,15 +12193,18 @@
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "encoding": {
           "version": "0.1.12",
           "bundled": true,
+          "dev": true,
           "requires": {
             "iconv-lite": "~0.4.13"
           }
@@ -12060,21 +12212,25 @@
         "end-of-stream": {
           "version": "1.4.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "^1.4.0"
           }
         },
         "env-paths": {
           "version": "2.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "err-code": {
           "version": "1.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "errno": {
           "version": "0.1.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "prr": "~1.0.1"
           }
@@ -12082,6 +12238,7 @@
         "es-abstract": {
           "version": "1.12.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.1.1",
             "function-bind": "^1.1.1",
@@ -12093,6 +12250,7 @@
         "es-to-primitive": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -12101,22 +12259,26 @@
         },
         "es6-promise": {
           "version": "4.2.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "es6-promisify": {
           "version": "5.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "es6-promise": "^4.0.3"
           }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "execa": {
           "version": "0.7.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -12129,37 +12291,45 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "figgy-pudding": {
           "version": "3.5.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "flush-write-stream": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.4"
@@ -12168,6 +12338,7 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -12181,6 +12352,7 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -12189,11 +12361,13 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "form-data": {
           "version": "2.3.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
@@ -12203,6 +12377,7 @@
         "from2": {
           "version": "2.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0"
@@ -12211,6 +12386,7 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -12224,6 +12400,7 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -12233,6 +12410,7 @@
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minipass": "^2.6.0"
           },
@@ -12240,6 +12418,7 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -12250,6 +12429,7 @@
         "fs-vacuum": {
           "version": "1.2.10",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "path-is-inside": "^1.0.1",
@@ -12259,6 +12439,7 @@
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "iferr": "^0.1.5",
@@ -12268,11 +12449,13 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -12286,6 +12469,7 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -12294,15 +12478,18 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -12316,11 +12503,13 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -12331,11 +12520,13 @@
         },
         "genfun": {
           "version": "5.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "gentle-fs": {
           "version": "2.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^1.1.2",
             "chownr": "^1.1.2",
@@ -12352,21 +12543,25 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "get-stream": {
           "version": "4.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
@@ -12374,6 +12569,7 @@
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
           }
@@ -12381,6 +12577,7 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -12393,6 +12590,7 @@
         "global-dirs": {
           "version": "0.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ini": "^1.3.4"
           }
@@ -12400,6 +12598,7 @@
         "got": {
           "version": "6.7.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "create-error-class": "^3.0.0",
             "duplexer3": "^0.1.4",
@@ -12416,21 +12615,25 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.2.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "har-validator": {
           "version": "5.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ajv": "^5.3.0",
             "har-schema": "^2.0.0"
@@ -12439,33 +12642,40 @@
         "has": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "has-symbols": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "hosted-git-info": {
           "version": "2.8.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "http-cache-semantics": {
           "version": "3.8.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "http-proxy-agent": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "agent-base": "4",
             "debug": "3.1.0"
@@ -12474,6 +12684,7 @@
         "http-signature": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
             "jsprim": "^1.2.2",
@@ -12483,6 +12694,7 @@
         "https-proxy-agent": {
           "version": "2.2.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "agent-base": "^4.3.0",
             "debug": "^3.1.0"
@@ -12491,6 +12703,7 @@
         "humanize-ms": {
           "version": "1.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ms": "^2.0.0"
           }
@@ -12498,36 +12711,43 @@
         "iconv-lite": {
           "version": "0.4.23",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "iferr": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
         },
         "import-lazy": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -12535,15 +12755,18 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "init-package-json": {
           "version": "1.10.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "^7.1.1",
             "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
@@ -12557,43 +12780,51 @@
         },
         "ip": {
           "version": "1.1.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ip-regex": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-callable": {
           "version": "1.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-ci": {
           "version": "1.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ci-info": "^1.5.0"
           },
           "dependencies": {
             "ci-info": {
               "version": "1.6.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "is-cidr": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cidr-regex": "^2.0.10"
           }
         },
         "is-date-object": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -12601,6 +12832,7 @@
         "is-installed-globally": {
           "version": "0.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "global-dirs": "^0.1.0",
             "is-path-inside": "^1.0.0"
@@ -12608,89 +12840,108 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "path-is-inside": "^1.0.1"
           }
         },
         "is-redirect": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "has": "^1.0.1"
           }
         },
         "is-retry-allowed": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-symbol": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.0"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
@@ -12701,17 +12952,20 @@
         "latest-version": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "package-json": "^4.0.0"
           }
         },
         "lazy-property": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "libcipm": {
           "version": "4.0.8",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.1",
@@ -12733,6 +12987,7 @@
         "libnpm": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.3",
@@ -12759,6 +13014,7 @@
         "libnpmaccess": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "get-stream": "^4.0.0",
@@ -12769,6 +13025,7 @@
         "libnpmconfig": {
           "version": "1.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
             "find-up": "^3.0.0",
@@ -12778,6 +13035,7 @@
             "find-up": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "locate-path": "^3.0.0"
               }
@@ -12785,6 +13043,7 @@
             "locate-path": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "p-locate": "^3.0.0",
                 "path-exists": "^3.0.0"
@@ -12793,6 +13052,7 @@
             "p-limit": {
               "version": "2.2.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -12800,19 +13060,22 @@
             "p-locate": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "p-limit": "^2.0.0"
               }
             },
             "p-try": {
               "version": "2.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "libnpmhook": {
           "version": "5.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
@@ -12823,6 +13086,7 @@
         "libnpmorg": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
@@ -12833,6 +13097,7 @@
         "libnpmpublish": {
           "version": "1.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.5.1",
@@ -12848,6 +13113,7 @@
         "libnpmsearch": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
             "get-stream": "^4.0.0",
@@ -12857,6 +13123,7 @@
         "libnpmteam": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
@@ -12867,6 +13134,7 @@
         "libnpx": {
           "version": "10.2.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "dotenv": "^5.0.1",
             "npm-package-arg": "^6.0.0",
@@ -12881,6 +13149,7 @@
         "lock-verify": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "npm-package-arg": "^6.1.0",
             "semver": "^5.4.1"
@@ -12889,17 +13158,20 @@
         "lockfile": {
           "version": "1.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "signal-exit": "^3.0.2"
           }
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lodash._createset": "~4.0.0",
             "lodash._root": "~3.0.0"
@@ -12907,58 +13179,71 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._createset": {
           "version": "4.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lru-cache": {
           "version": "5.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "yallist": "^3.0.2"
           }
@@ -12966,6 +13251,7 @@
         "make-dir": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pify": "^3.0.0"
           }
@@ -12973,6 +13259,7 @@
         "make-fetch-happen": {
           "version": "5.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "agentkeepalive": "^3.4.1",
             "cacache": "^12.0.0",
@@ -12989,15 +13276,18 @@
         },
         "meant": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mime-db": {
           "version": "1.35.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.19",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mime-db": "~1.35.0"
           }
@@ -13005,17 +13295,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minipass": "^2.9.0"
           },
@@ -13023,6 +13316,7 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -13033,6 +13327,7 @@
         "mississippi": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "concat-stream": "^1.5.0",
             "duplexify": "^3.4.2",
@@ -13049,19 +13344,22 @@
         "mkdirp": {
           "version": "0.5.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "^1.2.5"
           },
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^1.1.1",
             "copy-concurrently": "^1.0.0",
@@ -13073,21 +13371,25 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mute-stream": {
           "version": "0.0.7",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "node-fetch-npm": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "encoding": "^0.1.11",
             "json-parse-better-errors": "^1.0.0",
@@ -13097,6 +13399,7 @@
         "node-gyp": {
           "version": "5.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
@@ -13114,6 +13417,7 @@
         "nopt": {
           "version": "4.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -13122,6 +13426,7 @@
         "normalize-package-data": {
           "version": "2.5.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
             "resolve": "^1.10.0",
@@ -13132,6 +13437,7 @@
             "resolve": {
               "version": "1.10.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "path-parse": "^1.0.6"
               }
@@ -13141,6 +13447,7 @@
         "npm-audit-report": {
           "version": "1.3.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cli-table3": "^0.5.0",
             "console-control-strings": "^1.1.0"
@@ -13149,17 +13456,20 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "npm-install-checks": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
           }
@@ -13167,6 +13477,7 @@
         "npm-lifecycle": {
           "version": "3.1.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "byline": "^5.0.0",
             "graceful-fs": "^4.1.15",
@@ -13180,15 +13491,18 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "npm-package-arg": {
           "version": "6.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hosted-git-info": "^2.7.1",
             "osenv": "^0.1.5",
@@ -13199,6 +13513,7 @@
         "npm-packlist": {
           "version": "1.4.8",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1",
@@ -13208,6 +13523,7 @@
         "npm-pick-manifest": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
             "npm-package-arg": "^6.0.0",
@@ -13217,6 +13533,7 @@
         "npm-profile": {
           "version": "4.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^1.1.2 || 2",
             "figgy-pudding": "^3.4.1",
@@ -13226,6 +13543,7 @@
         "npm-registry-fetch": {
           "version": "4.0.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
@@ -13238,24 +13556,28 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "path-key": "^2.0.0"
           }
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -13265,23 +13587,28 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-keys": {
           "version": "1.0.12",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object.getownpropertydescriptors": {
           "version": "2.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.2",
             "es-abstract": "^1.5.1"
@@ -13290,25 +13617,30 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "opener": {
           "version": "1.5.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -13316,11 +13648,13 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "package-json": {
           "version": "4.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "got": "^6.7.1",
             "registry-auth-token": "^3.0.1",
@@ -13331,6 +13665,7 @@
         "pacote": {
           "version": "9.5.12",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
             "cacache": "^12.0.2",
@@ -13367,6 +13702,7 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -13377,6 +13713,7 @@
         "parallel-transform": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cyclist": "~0.2.2",
             "inherits": "^2.0.3",
@@ -13386,6 +13723,7 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -13399,6 +13737,7 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -13407,47 +13746,58 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "promise-retry": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "err-code": "^1.0.0",
             "retry": "^0.10.0"
@@ -13455,43 +13805,51 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "promzard": {
           "version": "0.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "read": "1"
           }
         },
         "proto-list": {
           "version": "1.2.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "protoduck": {
           "version": "5.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "genfun": "^5.0.0"
           }
         },
         "prr": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "psl": {
           "version": "1.1.29",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pump": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -13500,6 +13858,7 @@
         "pumpify": {
           "version": "1.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "duplexify": "^3.6.0",
             "inherits": "^2.0.3",
@@ -13509,6 +13868,7 @@
             "pump": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -13518,19 +13878,23 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "query-string": {
           "version": "6.8.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "split-on-first": "^1.0.0",
@@ -13539,11 +13903,13 @@
         },
         "qw": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
+          "dev": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -13554,6 +13920,7 @@
         "read": {
           "version": "1.0.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mute-stream": "~0.0.4"
           }
@@ -13561,6 +13928,7 @@
         "read-cmd-shim": {
           "version": "1.0.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2"
           }
@@ -13568,6 +13936,7 @@
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
             "graceful-fs": "^4.1.2",
@@ -13581,6 +13950,7 @@
         "read-package-json": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "^7.1.1",
             "graceful-fs": "^4.1.2",
@@ -13592,6 +13962,7 @@
         "read-package-tree": {
           "version": "5.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "read-package-json": "^2.0.0",
             "readdir-scoped-modules": "^1.0.0",
@@ -13601,6 +13972,7 @@
         "readable-stream": {
           "version": "3.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -13610,6 +13982,7 @@
         "readdir-scoped-modules": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
             "dezalgo": "^1.0.0",
@@ -13620,6 +13993,7 @@
         "registry-auth-token": {
           "version": "3.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "rc": "^1.1.6",
             "safe-buffer": "^5.0.1"
@@ -13628,6 +14002,7 @@
         "registry-url": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "rc": "^1.0.1"
           }
@@ -13635,6 +14010,7 @@
         "request": {
           "version": "2.88.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
             "aws4": "^1.8.0",
@@ -13660,23 +14036,28 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "retry": {
           "version": "0.12.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -13684,42 +14065,50 @@
         "run-queue": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "^1.1.1"
           },
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "semver": "^5.0.3"
           }
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "sha": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2"
           }
@@ -13727,29 +14116,35 @@
         "shebang-command": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "smart-buffer": {
           "version": "4.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "socks": {
           "version": "2.3.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ip": "1.1.5",
             "smart-buffer": "^4.1.0"
@@ -13758,6 +14153,7 @@
         "socks-proxy-agent": {
           "version": "4.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "agent-base": "~4.2.1",
             "socks": "~2.3.2"
@@ -13766,6 +14162,7 @@
             "agent-base": {
               "version": "4.2.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "es6-promisify": "^5.0.0"
               }
@@ -13774,11 +14171,13 @@
         },
         "sorted-object": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "from2": "^1.3.0",
             "stream-iterate": "^1.1.0"
@@ -13787,6 +14186,7 @@
             "from2": {
               "version": "1.3.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "inherits": "~2.0.1",
                 "readable-stream": "~1.1.10"
@@ -13794,11 +14194,13 @@
             },
             "isarray": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "readable-stream": {
               "version": "1.1.14",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -13808,13 +14210,15 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "spdx-correct": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
@@ -13822,11 +14226,13 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -13834,15 +14240,18 @@
         },
         "spdx-license-ids": {
           "version": "3.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "split-on-first": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "sshpk": {
           "version": "1.14.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "asn1": "~0.2.3",
             "assert-plus": "^1.0.0",
@@ -13858,6 +14267,7 @@
         "ssri": {
           "version": "6.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
           }
@@ -13865,6 +14275,7 @@
         "stream-each": {
           "version": "1.2.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "stream-shift": "^1.0.0"
@@ -13873,6 +14284,7 @@
         "stream-iterate": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
             "stream-shift": "^1.0.0"
@@ -13881,6 +14293,7 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -13894,6 +14307,7 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -13902,15 +14316,18 @@
         },
         "stream-shift": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -13918,15 +14335,18 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -13936,38 +14356,45 @@
         "string_decoder": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
           },
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "stringify-package": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -13975,6 +14402,7 @@
         "tar": {
           "version": "4.4.13",
           "bundled": true,
+          "dev": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -13988,6 +14416,7 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -13998,21 +14427,25 @@
         "term-size": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "execa": "^0.7.0"
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "through": {
           "version": "2.3.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "through2": {
           "version": "2.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
             "xtend": "~4.0.1"
@@ -14021,6 +14454,7 @@
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -14034,6 +14468,7 @@
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -14042,15 +14477,18 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
@@ -14059,6 +14497,7 @@
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -14066,23 +14505,28 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "unique-filename": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "unique-slug": "^2.0.0"
           }
@@ -14090,6 +14534,7 @@
         "unique-slug": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
           }
@@ -14097,21 +14542,25 @@
         "unique-string": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "crypto-random-string": "^1.0.0"
           }
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "unzip-response": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "update-notifier": {
           "version": "2.5.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "boxen": "^1.2.1",
             "chalk": "^2.0.1",
@@ -14128,32 +14577,38 @@
         "url-parse-lax": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "prepend-http": "^1.0.1"
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "util-extend": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "util-promisify": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "object.getownpropertydescriptors": "^2.0.3"
           }
         },
         "uuid": {
           "version": "3.3.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
@@ -14162,6 +14617,7 @@
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "builtins": "^1.0.3"
           }
@@ -14169,6 +14625,7 @@
         "verror": {
           "version": "1.10.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
@@ -14178,6 +14635,7 @@
         "wcwidth": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "defaults": "^1.0.3"
           }
@@ -14185,17 +14643,20 @@
         "which": {
           "version": "1.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "^1.0.2"
           },
@@ -14203,6 +14664,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -14214,6 +14676,7 @@
         "widest-line": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "^2.1.1"
           }
@@ -14221,6 +14684,7 @@
         "worker-farm": {
           "version": "1.7.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "errno": "~0.1.7"
           }
@@ -14228,6 +14692,7 @@
         "wrap-ansi": {
           "version": "5.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
             "string-width": "^3.0.0",
@@ -14236,15 +14701,18 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "string-width": {
               "version": "3.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "emoji-regex": "^7.0.1",
                 "is-fullwidth-code-point": "^2.0.0",
@@ -14254,6 +14722,7 @@
             "strip-ansi": {
               "version": "5.2.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "^4.1.0"
               }
@@ -14262,11 +14731,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
@@ -14275,23 +14746,28 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "xtend": {
           "version": "4.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yargs": {
           "version": "14.2.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cliui": "^5.0.0",
             "decamelize": "^1.2.0",
@@ -14308,22 +14784,26 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "find-up": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "locate-path": "^3.0.0"
               }
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "locate-path": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "p-locate": "^3.0.0",
                 "path-exists": "^3.0.0"
@@ -14332,6 +14812,7 @@
             "p-limit": {
               "version": "2.3.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -14339,17 +14820,20 @@
             "p-locate": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "p-limit": "^2.0.0"
               }
             },
             "p-try": {
               "version": "2.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "string-width": {
               "version": "3.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "emoji-regex": "^7.0.1",
                 "is-fullwidth-code-point": "^2.0.0",
@@ -14359,6 +14843,7 @@
             "strip-ansi": {
               "version": "5.2.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "^4.1.0"
               }
@@ -14368,6 +14853,7 @@
         "yargs-parser": {
           "version": "15.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -14375,7 +14861,8 @@
           "dependencies": {
             "camelcase": {
               "version": "5.3.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         }
@@ -16383,6 +16870,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -16393,7 +16881,8 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
         }
       }
     },
@@ -17425,6 +17914,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -17543,6 +18033,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
       "requires": {
         "rc": "^1.1.6",
         "safe-buffer": "^5.0.1"
@@ -17552,6 +18043,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
       "requires": {
         "rc": "^1.0.1"
       }
@@ -18170,6 +18662,7 @@
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/serve/-/serve-11.3.2.tgz",
       "integrity": "sha512-yKWQfI3xbj/f7X1lTBg91fXBP0FqjJ4TEi+ilES5yzH0iKJpN5LjNb1YzIfQg9Rqn4ECUS2SOf2+Kmepogoa5w==",
+      "dev": true,
       "requires": {
         "@zeit/schemas": "2.6.0",
         "ajv": "6.5.3",
@@ -18186,6 +18679,7 @@
           "version": "6.5.3",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
           "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -18197,6 +18691,7 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -18207,6 +18702,7 @@
           "version": "1.7.3",
           "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
           "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+          "dev": true,
           "requires": {
             "accepts": "~1.3.5",
             "bytes": "3.0.0",
@@ -18221,6 +18717,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -18228,12 +18725,14 @@
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
         },
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         }
       }
     },
@@ -18241,6 +18740,7 @@
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
       "integrity": "sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==",
+      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
@@ -18255,17 +18755,20 @@
         "content-disposition": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+          "dev": true
         },
         "mime-db": {
           "version": "1.33.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.18",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "dev": true,
           "requires": {
             "mime-db": "~1.33.0"
           }
@@ -18273,12 +18776,14 @@
         "path-to-regexp": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-          "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ=="
+          "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+          "dev": true
         },
         "range-parser": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+          "dev": true
         }
       }
     },
@@ -19309,6 +19814,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
       "requires": {
         "min-indent": "^1.0.0"
       }
@@ -19595,6 +20101,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
       "requires": {
         "execa": "^0.7.0"
       },
@@ -19603,6 +20110,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -19613,6 +20121,7 @@
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -19626,7 +20135,8 @@
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
         }
       }
     },
@@ -20105,7 +20615,8 @@
     "typescript": {
       "version": "3.9.7",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.21",
@@ -20333,6 +20844,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.2.tgz",
       "integrity": "sha512-1TrmYLuLj/5ZovwUS7fFd1jMH3NnFDN1y1A8dboedIDt7zs/zJMo6TwwlhYKkSeEwzleeiSBV5/3c9ufAQWDaQ==",
+      "dev": true,
       "requires": {
         "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0"
@@ -20603,7 +21115,8 @@
     "wait-for-expect": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
-      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag=="
+      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.7",
@@ -21417,6 +21930,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
       "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "dev": true,
       "requires": {
         "string-width": "^2.1.1"
       },
@@ -21424,17 +21938,20 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -21444,6 +21961,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,6 @@
   "dependencies": {
     "@ixo/ixo-apimodule": "^1.0.4",
     "@rjsf/core": "^2.2.2",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
-    "@types/react-select": "^3.0.21",
     "apexcharts": "^3.20.0",
     "bignumber.js": "^9.0.0",
     "chart.js": "^2.9.3",
@@ -21,7 +17,6 @@
     "js-base64": "^3.4.5",
     "lodash": "^4.17.20",
     "node-sass": "^4.14.1",
-    "npm": "^6.14.8",
     "qrcode": "^1.4.4",
     "react": "^16.13.1",
     "react-apexcharts": "^1.3.7",
@@ -63,11 +58,12 @@
     "redux-promise-middleware": "^6.1.2",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "serve": "^11.3.2",
-    "styled-components": "^5.1.1",
-    "typescript": "^3.9.7"
+    "styled-components": "^5.1.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.3.2",
+    "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/lodash": "^4.14.159",
     "@types/node": "^12.0.0",
@@ -82,11 +78,15 @@
     "@types/react-redux": "^7.1.9",
     "@types/react-responsive": "^8.0.2",
     "@types/react-router-dom": "^5.1.5",
+    "@types/react-select": "^3.0.21",
     "@types/react-virtualized": "^9.21.10",
     "@types/styled-components": "^5.1.2",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
-    "prettier": "^2.0.5"
+    "npm": "^6.14.8",
+    "prettier": "^2.0.5",
+    "serve": "^11.3.2",
+    "typescript": "^3.9.7"
   },
   "scripts": {
     "dev": "react-scripts start -h 0.0.0.0",


### PR DESCRIPTION
Development dependencies should be declared under the
"devDependencies" section in package.json.

Beside being helpful to people who analyze the codebase, this
distinction is also useful to a lot of automated tools.

A development dependency should never be declared as being a
production dependency unless there is a compelling reason.
