### PR TITLE
Cleanup unnecessary dotenv usages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "chart.js": "^2.9.3",
     "connected-react-router": "^6.8.0",
     "debounce": "^1.2.0",
-    "dotenv": "^8.2.0",
     "i": "^0.3.6",
     "immer": "^7.0.8",
     "ixo-assistant": "^0.9.0",

--- a/src/common/utils/formatters.ts
+++ b/src/common/utils/formatters.ts
@@ -1,6 +1,5 @@
 import moment from 'moment'
 import { isoCountries } from '../../lib/commonData'
-require('dotenv').config()
 
 export function excerptText(theText: string, words = 20): string {
   const cutOffCount = words

--- a/src/modules/App/App.tsx
+++ b/src/modules/App/App.tsx
@@ -17,8 +17,6 @@ import { Spinner } from '../../common/components/Spinner'
 import '../../assets/icons.css'
 import blocksyncApi from 'common/api/blocksync-api/blocksync-api'
 
-require('dotenv').config()
-
 ReactGA.initialize('UA-106630107-5')
 ReactGA.pageview(window.location.pathname + window.location.search)
 


### PR DESCRIPTION
Having dotenv as a dependency as well as calling it is completely unnecessary as environment variable loading is handled by CRA.

And in any case, dotenv can only work during the compile time and not the runtime in the case of a frontend app, so calling it in modules that are supposed to work during runtime has absolutely no effect.

Reference: https://www.npmjs.com/package/dotenv