### PR TITLE
Update Lodash imports to be tree shake-able

### DIFF
--- a/src/common/components/EntitySelector/EntitySelector.tsx
+++ b/src/common/components/EntitySelector/EntitySelector.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import _ from 'lodash'
+import { without, map, includes, get, upperFirst, toLower } from 'lodash'
 import Select from 'react-select'
 import Modal from '../Modal/Modal'
 import { Entity } from './types'
@@ -94,8 +94,8 @@ class EntitySelector extends React.Component<Props, State> {
     if (keyword === null || keyword.length <= 0) {
       tempEntities = entitiesFromProps
     } else {
-      tempEntities = _.without(_.map(entitiesFromProps, entity => {
-        if (_.includes(entity.did, keyword))
+      tempEntities = without(map(entitiesFromProps, entity => {
+        if (includes(entity.did, keyword))
           return entity
         return undefined
       }), undefined)
@@ -103,9 +103,9 @@ class EntitySelector extends React.Component<Props, State> {
 
     if (selectedOption !== null) {
       console.log('selectedOption',selectedOption)
-      _.map(tempEntities, entity => {
-        console.log(_.get(entity, 'ddoTags[1].tags', []))
-        if (_.includes(_.get(entity, 'ddoTags[1].tags', []), _.upperFirst(_.toLower(selectedOption))))
+      map(tempEntities, entity => {
+        console.log(get(entity, 'ddoTags[1].tags', []))
+        if (includes(get(entity, 'ddoTags[1].tags', []), upperFirst(toLower(selectedOption))))
           entities.push(entity)
       })
     } else {

--- a/src/common/components/QRCode/QRCode.tsx
+++ b/src/common/components/QRCode/QRCode.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import QRCode from "qrcode";
-import _ from 'lodash'
+import { replace } from 'lodash'
 import { QRContainer, QRInner, QRImg } from "./QRCode.styles";
 
 export interface Props {
@@ -13,7 +13,7 @@ export default class QRCodeComponent extends React.Component<Props> {
   };
 
   componentDidMount(): void {
-    const urlForQR = _.replace(this.props.url, '/overview', '')
+    const urlForQR = replace(this.props.url, '/overview', '')
     QRCode.toDataURL(urlForQR, {
       errorCorrectionLevel: "L",
       color: {

--- a/src/modules/BondModules/bond/bond.actions.ts
+++ b/src/modules/BondModules/bond/bond.actions.ts
@@ -1,7 +1,7 @@
 import Axios from "axios";
 import { BondActions, GetBalancesAction, GetTradesAction } from "./types";
 import { Dispatch } from "redux";
-import _ from 'lodash'
+import { get } from 'lodash'
 import { apiCurrencyToCurrency } from "../../Account/Account.utils";
 
 export const getBalances = (bondDid: string) => (
@@ -13,7 +13,7 @@ export const getBalances = (bondDid: string) => (
       transformResponse: [
         (response: string): any => {
           const parsedResponse = JSON.parse(response)
-          return _.get(parsedResponse, 'result.value', parsedResponse);
+          return get(parsedResponse, 'result.value', parsedResponse);
         },
       ],
     }
@@ -24,7 +24,7 @@ export const getBalances = (bondDid: string) => (
       transformResponse: [
         (response: string): any => {
           const parsedResponse = JSON.parse(response)
-          return _.get(parsedResponse, 'result', ['error'])[0];
+          return get(parsedResponse, 'result', ['error'])[0];
         },
       ],
     }
@@ -35,7 +35,7 @@ export const getBalances = (bondDid: string) => (
       transformResponse: [
         (response: string): any => {
           const parsedResponse = JSON.parse(response)
-          return _.get(parsedResponse, 'result', ['error'])[0];
+          return get(parsedResponse, 'result', ['error'])[0];
         },
       ],
     }

--- a/src/pages/bond/accounts/components/ProjectAccountWrapper.tsx
+++ b/src/pages/bond/accounts/components/ProjectAccountWrapper.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash'
+import { chunk } from 'lodash'
 import styled from 'styled-components'
 
 export interface ProjectAccountWrapperProps {
@@ -45,7 +45,7 @@ const Header = () => (
 )
 
 export default function ProjectAccountWrapper ({children}: ProjectAccountWrapperProps): JSX.Element {
-  const childsArray = _.chunk(React.Children.toArray(children), 4)
+  const childsArray = chunk(React.Children.toArray(children), 4)
 
   if (React.Children.count(children) > 4)
     return (

--- a/src/pages/investment/accounts/components/ProjectAccountWrapper.tsx
+++ b/src/pages/investment/accounts/components/ProjectAccountWrapper.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash'
+import { chunk } from 'lodash'
 import styled from 'styled-components'
 
 export interface ProjectAccountWrapperProps {
@@ -45,7 +45,7 @@ const Header = () => (
 )
 
 export default function ProjectAccountWrapper ({children}: ProjectAccountWrapperProps): JSX.Element {
-  const childsArray = _.chunk(React.Children.toArray(children), 4)
+  const childsArray = chunk(React.Children.toArray(children), 4)
 
   if (React.Children.count(children) > 4)
     return (


### PR DESCRIPTION
Importing the whole Lodash library will unnecessarily cause the bundle size to increase a lot. (As is the same with any library with a utility belt nature)

Cherry pick import the required functions from Lodash to enable a module bundler to do some tree shaking magic, which will in turn cause the bundle size to decrease.

Reference: https://webpack.js.org/guides/tree-shaking/