### PR TITLE
Show correct format for markdown of cards content in project overview page

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-scripts": "3.4.1",
     "react-scroll": "^1.8.1",
     "react-select": "^3.1.0",
+    "react-showdown": "^2.3.1",
     "react-simple-maps": "^0.12.1",
     "react-soundplayer": "^1.0.5",
     "react-spring": "^8.0.27",

--- a/src/modules/Entities/SelectedEntity/EntityOverview/components/BodyContentCard/BodyContentCard.styles.ts
+++ b/src/modules/Entities/SelectedEntity/EntityOverview/components/BodyContentCard/BodyContentCard.styles.ts
@@ -21,7 +21,7 @@ export const Container = styled(SectionContainer)`
       width: 50%;
       margin-bottom: 0;
     }
-    p {
+    p.content {
       width: calc(50% - 1.35rem);
       margin-left: 1.25rem;
     }

--- a/src/modules/Entities/SelectedEntity/EntityOverview/components/BodyContentCard/BodyContentCard.tsx
+++ b/src/modules/Entities/SelectedEntity/EntityOverview/components/BodyContentCard/BodyContentCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from './BodyContentCard.styles'
+import MarkdownView from 'react-showdown';
 
 interface Props {
   title: string
@@ -17,7 +18,12 @@ const BodyContentCard: React.FunctionComponent<Props> = ({
       <h2>{title}</h2>
       <Container>
         <img src={image} alt={title} />
-        <p className="content">{content}</p>
+        <p className="content">
+          <MarkdownView
+            markdown={content}
+            options={{ tables: true, emoji: true }}
+          />
+        </p>
       </Container>
     </>
   )

--- a/src/modules/Entities/SelectedEntity/EntityOverview/components/ImageContentCard/ImageContentCard.tsx
+++ b/src/modules/Entities/SelectedEntity/EntityOverview/components/ImageContentCard/ImageContentCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from './ImageContentCard.styles'
+import MarkdownView from 'react-showdown';
 
 interface Props {
   title: string
@@ -18,7 +19,12 @@ const ImageContentCard: React.FunctionComponent<Props> = ({
     <>
       <h2>{title}</h2>
       <Container>
-        <p className="content">{content}</p>
+        <p className="content">
+          <MarkdownView
+            markdown={content}
+            options={{ tables: true, emoji: true }}
+          />
+        </p>
         {image && <img src={image} alt={title} />}
         <p className="caption">{imageDescription}</p>
       </Container>


### PR DESCRIPTION
## Scope
- Show correct format for markdown of cards content in project overview pages
## Work Done
- Added react-markdown package for showing correct format of markdown of cards content
## Steps to Test
To test it you need to find the specific project which contains markdown format(e.g: "**Impact Hub** ")
## Screenshots
