### PR TITLE
msgBeginRedelegation messaging with Keysafe

### DIFF
--- a/src/common/components/ControlPanel/Actions/Actions.tsx
+++ b/src/common/components/ControlPanel/Actions/Actions.tsx
@@ -186,8 +186,12 @@ const Actions: React.FunctionComponent<Props> = ({
           validator_address: validatorAddress,
         },
       }
+      const fee = {
+        amount: [{ amount: String(5000), denom: 'uixo' }],
+        gas: String(200000),
+      }
 
-      broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+      broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
         setDelegateModalOpen(false)
       })
     }
@@ -213,7 +217,12 @@ const Actions: React.FunctionComponent<Props> = ({
       },
     }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    const fee = {
+      amount: [{ amount: String(7500), denom: 'uixo' }],
+      gas: String(300000),
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       setRedelegateModalOpen(false)
     })
   }
@@ -231,8 +240,12 @@ const Actions: React.FunctionComponent<Props> = ({
         bond_did: bondDid,
       },
     }
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
+    }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       setBuyModalOpen(false)
     })
   }
@@ -250,7 +263,12 @@ const Actions: React.FunctionComponent<Props> = ({
       },
     }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       setSellModalOpen(false)
     })
   }
@@ -262,9 +280,14 @@ const Actions: React.FunctionComponent<Props> = ({
         recipient_did: userDid,
         bond_did: bondDid,
       },
+
+    }
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
     }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       // setBuyModalOpen(false)
     })
   }
@@ -313,7 +336,12 @@ const Actions: React.FunctionComponent<Props> = ({
         },
       }
 
-      broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+      const fee = {
+        amount: [{ amount: String(5000), denom: 'uixo' }],
+        gas: String(200000),
+      }
+
+      broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
         setWithdrawDelegationRewardModalOpen(false)
       })
     }
@@ -382,12 +410,19 @@ const Actions: React.FunctionComponent<Props> = ({
               to_address: receiverAddress,
             },
           }
+
+          const fee = {
+            amount: [{ amount: String(5000), denom: 'uixo' }],
+            gas: String(200000),
+          }
+
           broadCast(
             userInfo,
             userSequence,
             userAccountNumber,
             msg,
             memo,
+            fee,
             () => {
               setSendModalOpen(false)
             },
@@ -441,7 +476,12 @@ const Actions: React.FunctionComponent<Props> = ({
       },
     }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       setProposalModalOpen(false)
     })
   }
@@ -503,7 +543,12 @@ const Actions: React.FunctionComponent<Props> = ({
         },
       }
 
-      broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+      const fee = {
+        amount: [{ amount: String(5000), denom: 'uixo' }],
+        gas: String(200000),
+      }
+
+      broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
         setDepositModalOpen(false)
       })
     }
@@ -557,7 +602,12 @@ const Actions: React.FunctionComponent<Props> = ({
         },
       }
 
-      broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+      const fee = {
+        amount: [{ amount: String(5000), denom: 'uixo' }],
+        gas: String(200000),
+      }
+
+      broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
         setVoteModalOpen(false)
       })
     }
@@ -587,7 +637,12 @@ const Actions: React.FunctionComponent<Props> = ({
       },
     }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       console.log('handleUpdateValidator')
     })
   }
@@ -598,7 +653,12 @@ const Actions: React.FunctionComponent<Props> = ({
       value: json,
     }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       console.log('handleMultiSend')
     })
   }

--- a/src/common/components/ControlPanel/Actions/Actions.tsx
+++ b/src/common/components/ControlPanel/Actions/Actions.tsx
@@ -52,6 +52,7 @@ import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx'
 import { MsgWithdrawDelegatorReward } from 'cosmjs-types/cosmos/distribution/v1beta1/tx'
 import FuelEntityModal from './FuelEntityModal'
 import { Currency } from 'types/models'
+import RedelegateModal from './RedelegateModal'
 
 declare const window: any
 interface IconTypes {
@@ -99,6 +100,7 @@ const Actions: React.FunctionComponent<Props> = ({
   handleUpdateProjectStatusToStarted,
 }) => {
   const [delegateModalOpen, setDelegateModalOpen] = useState(false)
+  const [redelegateModalOpen, setRedelegateModalOpen] = useState(false)
   const [buyModalOpen, setBuyModalOpen] = useState(false)
   const [sellModalOpen, setSellModalOpen] = useState(false)
   const [proposalModalOpen, setProposalModalOpen] = useState(false)
@@ -189,6 +191,31 @@ const Actions: React.FunctionComponent<Props> = ({
         setDelegateModalOpen(false)
       })
     }
+  }
+
+  const handleRedelegate = async (
+    amount: number,
+    validatorSrcAddress: string,
+    validatorDstAddress: string,
+  ): Promise<void> => {
+    console.log(11111111, amount, validatorSrcAddress, validatorDstAddress)
+    if (!userDid) return
+    const msg = {
+      type: 'cosmos-sdk/MsgBeginRedelegate',
+      value: {
+        amount: {
+          amount: getUIXOAmount(String(amount)),
+          denom: 'uixo',
+        },
+        delegator_address: userAddress,
+        validator_dst_address: validatorDstAddress,
+        validator_src_address: validatorSrcAddress,
+      },
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+      setRedelegateModalOpen(false)
+    })
   }
 
   const handleBuy = (amount: number): void => {
@@ -613,6 +640,9 @@ const Actions: React.FunctionComponent<Props> = ({
         case 'delegate':
           setDelegateModalOpen(true)
           return
+        case 'redelegate':
+          setRedelegateModalOpen(true)
+          return
         case 'buy':
           setBuyModalOpen(true)
           return
@@ -750,6 +780,12 @@ const Actions: React.FunctionComponent<Props> = ({
         handleToggleModal={(): void => setDelegateModalOpen(false)}
       >
         <DelegateModal handleDelegate={handleDelegate} />
+      </ModalWrapper>
+      <ModalWrapper
+        isModalOpen={redelegateModalOpen}
+        handleToggleModal={(): void => setRedelegateModalOpen(false)}
+      >
+        <RedelegateModal handleRedelegate={handleRedelegate} />
       </ModalWrapper>
       <ModalWrapper
         isModalOpen={withdrawDelegationRewardModalOpen}

--- a/src/common/components/ControlPanel/Actions/RedelegateModal.tsx
+++ b/src/common/components/ControlPanel/Actions/RedelegateModal.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import styled from 'styled-components'
+import InputText from 'common/components/Form/InputText/InputText'
+import { FormStyles } from 'types/models'
+
+const Container = styled.div`
+  padding: 1rem 1rem;
+  min-width: 32rem;
+`
+
+const ButtonContainer = styled.div`
+  text-align: center;
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+
+  button {
+    border: 1px solid #00d2ff;
+    border-radius: 0.25rem;
+    height: 2.25rem;
+    width: 6.5rem;
+    background: transparent;
+    color: white;
+    outline: none;
+  }
+`
+
+interface Props {
+  handleRedelegate: (amount: number, validatorSrcAddress: string, validatorDstAddress: string) => void
+}
+
+const RedelegateModal: React.FunctionComponent<Props> = ({ handleRedelegate }) => {
+  const handleSubmit = (event): void => {
+    event.preventDefault()
+
+    const amount = event.target.elements['amount'].value
+    const validatorSrcAddress = event.target.elements['validatorSrcAddress'].value
+    const validatorDstAddress = event.target.elements['validatorDstAddress'].value
+
+    if (amount && validatorSrcAddress && validatorDstAddress) {
+      handleRedelegate(amount, validatorSrcAddress, validatorDstAddress)
+    }
+  }
+
+  return (
+    <Container>
+      <form onSubmit={handleSubmit}>
+        <InputText
+          type="number"
+          formStyle={FormStyles.modal}
+          text="Amount"
+          id="amount"
+          step="0.000001"
+        />
+        <InputText
+          type="text"
+          id="validatorSrcAddress"
+          formStyle={FormStyles.modal}
+          text="Validator Src Address"
+        />
+        <InputText
+          type="text"
+          id="validatorDstAddress"
+          formStyle={FormStyles.modal}
+          text="Validator Dst Address"
+        />
+        <ButtonContainer>
+          <button type="submit">Redelegate</button>
+        </ButtonContainer>
+      </form>
+    </Container>
+  )
+}
+
+export default RedelegateModal

--- a/src/common/components/ControlPanel/schema/Cell.schema.json
+++ b/src/common/components/ControlPanel/schema/Cell.schema.json
@@ -173,6 +173,29 @@
         ]
       },
       {
+        "@type": "Redelegate",
+        "@id": "actionRedelegate",
+        "title": "Redelegate",
+        "tooltip": "Redelegate",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "redelegate"
+          }
+        ]
+      },
+      {
         "@type": "Buy",
         "@id": "actionBuy",
         "title": "Buy",

--- a/src/common/components/ControlPanel/schema/Data.schema.json
+++ b/src/common/components/ControlPanel/schema/Data.schema.json
@@ -173,6 +173,29 @@
         ]
       },
       {
+        "@type": "Redelegate",
+        "@id": "actionRedelegate",
+        "title": "Redelegate",
+        "tooltip": "Redelegate",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "redelegate"
+          }
+        ]
+      },
+      {
         "@type": "Buy",
         "@id": "actionBuy",
         "title": "Buy",

--- a/src/common/components/ControlPanel/schema/Investment.schema.json
+++ b/src/common/components/ControlPanel/schema/Investment.schema.json
@@ -173,6 +173,29 @@
         ]
       },
       {
+        "@type": "Redelegate",
+        "@id": "actionRedelegate",
+        "title": "Redelegate",
+        "tooltip": "Redelegate",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "redelegate"
+          }
+        ]
+      },
+      {
         "@type": "Buy",
         "@id": "actionBuy",
         "title": "Buy",

--- a/src/common/components/ControlPanel/schema/Oracle.schema.json
+++ b/src/common/components/ControlPanel/schema/Oracle.schema.json
@@ -173,6 +173,29 @@
         ]
       },
       {
+        "@type": "Redelegate",
+        "@id": "actionRedelegate",
+        "title": "Redelegate",
+        "tooltip": "Redelegate",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "redelegate"
+          }
+        ]
+      },
+      {
         "@type": "Buy",
         "@id": "actionBuy",
         "title": "Buy",

--- a/src/common/components/ControlPanel/schema/Project.schema.json
+++ b/src/common/components/ControlPanel/schema/Project.schema.json
@@ -242,6 +242,29 @@
         ]
       },
       {
+        "@type": "Redelegate",
+        "@id": "actionRedelegate",
+        "title": "Redelegate",
+        "tooltip": "Redelegate",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "redelegate"
+          }
+        ]
+      },
+      {
         "@type": "Buy",
         "@id": "actionBuy",
         "title": "Buy",

--- a/src/common/components/ControlPanel/schema/Template.schema.json
+++ b/src/common/components/ControlPanel/schema/Template.schema.json
@@ -196,6 +196,29 @@
         ]
       },
       {
+        "@type": "Redelegate",
+        "@id": "actionRedelegate",
+        "title": "Redelegate",
+        "tooltip": "Redelegate",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "redelegate"
+          }
+        ]
+      },
+      {
         "@type": "Buy",
         "@id": "actionBuy",
         "title": "Buy",

--- a/src/common/utils/keysafe.ts
+++ b/src/common/utils/keysafe.ts
@@ -10,15 +10,13 @@ export const broadCastMessage = (
   userAccountNumber,
   msg,
   memo = '',
+  fee,
   callback,
 ): void => {
   const payload = {
     msgs: [msg],
     chain_id: process.env.REACT_APP_CHAIN_ID,
-    fee: {
-      amount: [{ amount: String(5000), denom: 'uixo' }],
-      gas: String(200000),
-    },
+    fee,
     memo,
     account_number: String(userAccountNumber),
     sequence: String(userSequence),


### PR DESCRIPTION
## Scope

## Work Done
- Redelegation Modal built
- Redelegation Action button for all entity types
- Dynamic fee for Keysafe messaging
- set `msgBeginRedelegation` fee as 
    `const fee = {
      amount: [{ amount: String(7500), denom: 'uixo' }],
      gas: String(300000)
    }`

## Steps to Test
- click Redelegate button on Actions panel

## Screenshots
![image](https://user-images.githubusercontent.com/50171204/136585488-c7318683-4f55-48e3-a13c-6814c0655426.png)
