### PR TITLE
MsgModifyWithdrawAddress message with Keysafe wallet

### DIFF
--- a/src/common/components/ControlPanel/Actions/Actions.tsx
+++ b/src/common/components/ControlPanel/Actions/Actions.tsx
@@ -53,6 +53,7 @@ import { MsgWithdrawDelegatorReward } from 'cosmjs-types/cosmos/distribution/v1b
 import FuelEntityModal from './FuelEntityModal'
 import { Currency } from 'types/models'
 import RedelegateModal from './RedelegateModal'
+import ModifyWithdrawAddressModal from './ModifyWithdrawAddressModal'
 
 declare const window: any
 interface IconTypes {
@@ -115,6 +116,7 @@ const Actions: React.FunctionComponent<Props> = ({
     withdrawDelegationRewardModalOpen,
     setWithdrawDelegationRewardModalOpen,
   ] = useState(false)
+  const [modifyWithdrawAddressModalOpen, setModifyWithdrawAddressModalOpen] = useState(false)
 
   useEffect(() => {
     Axios.get(`${process.env.REACT_APP_GAIA_URL}/staking/validators`).then(
@@ -345,6 +347,26 @@ const Actions: React.FunctionComponent<Props> = ({
         setWithdrawDelegationRewardModalOpen(false)
       })
     }
+  }
+
+  const handleModifyWithdrawAddress = (address: string): void => {
+    if (!userAddress) return
+    const msg = {
+      type: 'cosmos-sdk/MsgModifyWithdrawAddress',
+      value: {
+				delegator_address: userAddress,
+				withdraw_address: address
+      },
+    }
+
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
+      setModifyWithdrawAddressModalOpen(false)
+    })
   }
 
   const handleSend = async (
@@ -712,6 +734,9 @@ const Actions: React.FunctionComponent<Props> = ({
         case 'withdrawdelegationreward':
           setWithdrawDelegationRewardModalOpen(true)
           return
+        case 'modifywithdrawaddress':
+          setModifyWithdrawAddressModalOpen(true)
+          return
         case 'sell':
           setSellModalOpen(true)
           return
@@ -855,6 +880,16 @@ const Actions: React.FunctionComponent<Props> = ({
       >
         <WithdrawDelegationRewardModal
           handleWithdrawDelegationReward={handleWithdrawDelegationReward}
+        />
+      </ModalWrapper>
+      <ModalWrapper
+        isModalOpen={modifyWithdrawAddressModalOpen}
+        handleToggleModal={(): void =>
+          setModifyWithdrawAddressModalOpen(false)
+        }
+      >
+        <ModifyWithdrawAddressModal
+          handleModifyWithdrawAddress={handleModifyWithdrawAddress}
         />
       </ModalWrapper>
       <ModalWrapper

--- a/src/common/components/ControlPanel/Actions/Actions.tsx
+++ b/src/common/components/ControlPanel/Actions/Actions.tsx
@@ -186,8 +186,12 @@ const Actions: React.FunctionComponent<Props> = ({
           validator_address: validatorAddress,
         },
       }
+      const fee = {
+        amount: [{ amount: String(5000), denom: 'uixo' }],
+        gas: String(200000),
+      }
 
-      broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+      broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
         setDelegateModalOpen(false)
       })
     }
@@ -213,7 +217,12 @@ const Actions: React.FunctionComponent<Props> = ({
       },
     }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    const fee = {
+      amount: [{ amount: String(7500), denom: 'uixo' }],
+      gas: String(300000),
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       setRedelegateModalOpen(false)
     })
   }
@@ -231,8 +240,12 @@ const Actions: React.FunctionComponent<Props> = ({
         bond_did: bondDid,
       },
     }
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
+    }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       setBuyModalOpen(false)
     })
   }
@@ -250,7 +263,12 @@ const Actions: React.FunctionComponent<Props> = ({
       },
     }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       setSellModalOpen(false)
     })
   }
@@ -262,9 +280,14 @@ const Actions: React.FunctionComponent<Props> = ({
         recipient_did: userDid,
         bond_did: bondDid,
       },
+
+    }
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
     }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       // setBuyModalOpen(false)
     })
   }
@@ -313,7 +336,12 @@ const Actions: React.FunctionComponent<Props> = ({
         },
       }
 
-      broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+      const fee = {
+        amount: [{ amount: String(5000), denom: 'uixo' }],
+        gas: String(200000),
+      }
+
+      broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
         setWithdrawDelegationRewardModalOpen(false)
       })
     }
@@ -382,12 +410,19 @@ const Actions: React.FunctionComponent<Props> = ({
               to_address: receiverAddress,
             },
           }
+
+          const fee = {
+            amount: [{ amount: String(5000), denom: 'uixo' }],
+            gas: String(200000),
+          }
+
           broadCast(
             userInfo,
             userSequence,
             userAccountNumber,
             msg,
             memo,
+            fee,
             () => {
               setSendModalOpen(false)
             },
@@ -441,7 +476,12 @@ const Actions: React.FunctionComponent<Props> = ({
       },
     }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       setProposalModalOpen(false)
     })
   }
@@ -503,7 +543,12 @@ const Actions: React.FunctionComponent<Props> = ({
         },
       }
 
-      broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+      const fee = {
+        amount: [{ amount: String(5000), denom: 'uixo' }],
+        gas: String(200000),
+      }
+
+      broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
         setDepositModalOpen(false)
       })
     }
@@ -557,7 +602,12 @@ const Actions: React.FunctionComponent<Props> = ({
         },
       }
 
-      broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+      const fee = {
+        amount: [{ amount: String(5000), denom: 'uixo' }],
+        gas: String(200000),
+      }
+
+      broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
         setVoteModalOpen(false)
       })
     }
@@ -587,7 +637,12 @@ const Actions: React.FunctionComponent<Props> = ({
       },
     }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       console.log('handleUpdateValidator')
     })
   }
@@ -598,7 +653,12 @@ const Actions: React.FunctionComponent<Props> = ({
       value: json,
     }
 
-    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+    const fee = {
+      amount: [{ amount: String(5000), denom: 'uixo' }],
+      gas: String(200000),
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', fee, () => {
       console.log('handleMultiSend')
     })
   }

--- a/src/common/components/ControlPanel/Actions/Actions.tsx
+++ b/src/common/components/ControlPanel/Actions/Actions.tsx
@@ -52,6 +52,7 @@ import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx'
 import { MsgWithdrawDelegatorReward } from 'cosmjs-types/cosmos/distribution/v1beta1/tx'
 import FuelEntityModal from './FuelEntityModal'
 import { Currency } from 'types/models'
+import RedelegateModal from './RedelegateModal'
 
 declare const window: any
 interface IconTypes {
@@ -99,6 +100,7 @@ const Actions: React.FunctionComponent<Props> = ({
   handleUpdateProjectStatusToStarted,
 }) => {
   const [delegateModalOpen, setDelegateModalOpen] = useState(false)
+  const [redelegateModalOpen, setRedelegateModalOpen] = useState(false)
   const [buyModalOpen, setBuyModalOpen] = useState(false)
   const [sellModalOpen, setSellModalOpen] = useState(false)
   const [proposalModalOpen, setProposalModalOpen] = useState(false)
@@ -189,6 +191,31 @@ const Actions: React.FunctionComponent<Props> = ({
         setDelegateModalOpen(false)
       })
     }
+  }
+
+  const handleRedelegate = async (
+    amount: number,
+    validatorSrcAddress: string,
+    validatorDstAddress: string,
+  ): Promise<void> => {
+    console.log(11111111, amount, validatorSrcAddress, validatorDstAddress)
+    if (!userDid) return
+    const msg = {
+      type: 'cosmos-sdk/MsgBeginRedelegate',
+      value: {
+        amount: {
+          amount: getUIXOAmount(String(amount)),
+          denom: 'uixo',
+        },
+        delegator_address: userAddress,
+        validator_dst_address: validatorDstAddress,
+        validator_src_address: validatorSrcAddress,
+      },
+    }
+
+    broadCast(userInfo, userSequence, userAccountNumber, msg, '', () => {
+      setRedelegateModalOpen(false)
+    })
   }
 
   const handleBuy = (amount: number): void => {
@@ -613,6 +640,9 @@ const Actions: React.FunctionComponent<Props> = ({
         case 'delegate':
           setDelegateModalOpen(true)
           return
+        case 'redelegate':
+          setRedelegateModalOpen(true)
+          return
         case 'buy':
           setBuyModalOpen(true)
           return
@@ -750,6 +780,12 @@ const Actions: React.FunctionComponent<Props> = ({
         handleToggleModal={(): void => setDelegateModalOpen(false)}
       >
         <DelegateModal handleDelegate={handleDelegate} />
+      </ModalWrapper>
+      <ModalWrapper
+        isModalOpen={redelegateModalOpen}
+        handleToggleModal={(): void => setRedelegateModalOpen(false)}
+      >
+        <RedelegateModal handleRedelegate={handleRedelegate} />
       </ModalWrapper>
       <ModalWrapper
         isModalOpen={withdrawDelegationRewardModalOpen}

--- a/src/common/components/ControlPanel/Actions/ModifyWithdrawAddressModal.tsx
+++ b/src/common/components/ControlPanel/Actions/ModifyWithdrawAddressModal.tsx
@@ -1,0 +1,59 @@
+import React, { FunctionComponent } from 'react'
+import styled from 'styled-components'
+import InputText from 'common/components/Form/InputText/InputText'
+import { FormStyles } from 'types/models'
+
+const Container = styled.div`
+  padding: 1rem 1rem;
+  min-width: 32rem;
+`
+
+const ButtonContainer = styled.div`
+  text-align: center;
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+
+  button {
+    border: 1px solid #00d2ff;
+    border-radius: 0.25rem;
+    height: 2.25rem;
+    background: transparent;
+    color: white;
+    outline: none;
+  }
+`
+
+interface Props {
+  handleModifyWithdrawAddress: (address: string) => void
+}
+
+const ModifyWithdrawAddressModal: FunctionComponent<Props> = ({ handleModifyWithdrawAddress }) => {
+  const handleSubmit = (event): void => {
+    event.preventDefault()
+
+    const address = event.target.elements['address'].value
+
+    if (address) {
+      handleModifyWithdrawAddress(address)
+    }
+  }
+
+  return (
+    <Container>
+      <form onSubmit={handleSubmit}>
+        <InputText
+          type="text"
+          formStyle={FormStyles.modal}
+          text="Withdraw Address"
+          id="address"
+        />
+
+        <ButtonContainer>
+          <button type="submit">Modify Withdraw Address</button>
+        </ButtonContainer>
+      </form>
+    </Container>
+  )
+}
+
+export default ModifyWithdrawAddressModal

--- a/src/common/components/ControlPanel/Actions/RedelegateModal.tsx
+++ b/src/common/components/ControlPanel/Actions/RedelegateModal.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import styled from 'styled-components'
+import InputText from 'common/components/Form/InputText/InputText'
+import { FormStyles } from 'types/models'
+
+const Container = styled.div`
+  padding: 1rem 1rem;
+  min-width: 32rem;
+`
+
+const ButtonContainer = styled.div`
+  text-align: center;
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+
+  button {
+    border: 1px solid #00d2ff;
+    border-radius: 0.25rem;
+    height: 2.25rem;
+    width: 6.5rem;
+    background: transparent;
+    color: white;
+    outline: none;
+  }
+`
+
+interface Props {
+  handleRedelegate: (amount: number, validatorSrcAddress: string, validatorDstAddress: string) => void
+}
+
+const RedelegateModal: React.FunctionComponent<Props> = ({ handleRedelegate }) => {
+  const handleSubmit = (event): void => {
+    event.preventDefault()
+
+    const amount = event.target.elements['amount'].value
+    const validatorSrcAddress = event.target.elements['validatorSrcAddress'].value
+    const validatorDstAddress = event.target.elements['validatorDstAddress'].value
+
+    if (amount && validatorSrcAddress && validatorDstAddress) {
+      handleRedelegate(amount, validatorSrcAddress, validatorDstAddress)
+    }
+  }
+
+  return (
+    <Container>
+      <form onSubmit={handleSubmit}>
+        <InputText
+          type="number"
+          formStyle={FormStyles.modal}
+          text="Amount"
+          id="amount"
+          step="0.000001"
+        />
+        <InputText
+          type="text"
+          id="validatorSrcAddress"
+          formStyle={FormStyles.modal}
+          text="Validator Src Address"
+        />
+        <InputText
+          type="text"
+          id="validatorDstAddress"
+          formStyle={FormStyles.modal}
+          text="Validator Dst Address"
+        />
+        <ButtonContainer>
+          <button type="submit">Redelegate</button>
+        </ButtonContainer>
+      </form>
+    </Container>
+  )
+}
+
+export default RedelegateModal

--- a/src/common/components/ControlPanel/schema/Cell.schema.json
+++ b/src/common/components/ControlPanel/schema/Cell.schema.json
@@ -265,6 +265,29 @@
         ]
       },
       {
+        "@type": "ModifyWithdrawAddress",
+        "@id": "actionModifyWithdrawAddress",
+        "title": "Modify Withdraw Address",
+        "tooltip": "Modify Withdraw Address",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "modifywithdrawaddress"
+          }
+        ]
+      },
+      {
         "@type": "WithdrawDelegationReward",
         "@id": "actionWithdrawDelegationReward",
         "title": "Withdraw Delegation Reward",

--- a/src/common/components/ControlPanel/schema/Cell.schema.json
+++ b/src/common/components/ControlPanel/schema/Cell.schema.json
@@ -173,6 +173,29 @@
         ]
       },
       {
+        "@type": "Redelegate",
+        "@id": "actionRedelegate",
+        "title": "Redelegate",
+        "tooltip": "Redelegate",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "redelegate"
+          }
+        ]
+      },
+      {
         "@type": "Buy",
         "@id": "actionBuy",
         "title": "Buy",

--- a/src/common/components/ControlPanel/schema/Data.schema.json
+++ b/src/common/components/ControlPanel/schema/Data.schema.json
@@ -265,6 +265,29 @@
         ]
       },
       {
+        "@type": "ModifyWithdrawAddress",
+        "@id": "actionModifyWithdrawAddress",
+        "title": "Modify Withdraw Address",
+        "tooltip": "Modify Withdraw Address",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "modifywithdrawaddress"
+          }
+        ]
+      },
+      {
         "@type": "WithdrawDelegationReward",
         "@id": "actionWithdrawDelegationReward",
         "title": "Withdraw Delegation Reward",

--- a/src/common/components/ControlPanel/schema/Data.schema.json
+++ b/src/common/components/ControlPanel/schema/Data.schema.json
@@ -173,6 +173,29 @@
         ]
       },
       {
+        "@type": "Redelegate",
+        "@id": "actionRedelegate",
+        "title": "Redelegate",
+        "tooltip": "Redelegate",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "redelegate"
+          }
+        ]
+      },
+      {
         "@type": "Buy",
         "@id": "actionBuy",
         "title": "Buy",

--- a/src/common/components/ControlPanel/schema/Investment.schema.json
+++ b/src/common/components/ControlPanel/schema/Investment.schema.json
@@ -265,6 +265,29 @@
         ]
       },
       {
+        "@type": "ModifyWithdrawAddress",
+        "@id": "actionModifyWithdrawAddress",
+        "title": "Modify Withdraw Address",
+        "tooltip": "Modify Withdraw Address",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "modifywithdrawaddress"
+          }
+        ]
+      },
+      {
         "@type": "WithdrawDelegationReward",
         "@id": "actionWithdrawDelegationReward",
         "title": "Withdraw Delegation Reward",

--- a/src/common/components/ControlPanel/schema/Investment.schema.json
+++ b/src/common/components/ControlPanel/schema/Investment.schema.json
@@ -173,6 +173,29 @@
         ]
       },
       {
+        "@type": "Redelegate",
+        "@id": "actionRedelegate",
+        "title": "Redelegate",
+        "tooltip": "Redelegate",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "redelegate"
+          }
+        ]
+      },
+      {
         "@type": "Buy",
         "@id": "actionBuy",
         "title": "Buy",

--- a/src/common/components/ControlPanel/schema/Oracle.schema.json
+++ b/src/common/components/ControlPanel/schema/Oracle.schema.json
@@ -265,6 +265,29 @@
         ]
       },
       {
+        "@type": "ModifyWithdrawAddress",
+        "@id": "actionModifyWithdrawAddress",
+        "title": "Modify Withdraw Address",
+        "tooltip": "Modify Withdraw Address",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "modifywithdrawaddress"
+          }
+        ]
+      },
+      {
         "@type": "WithdrawDelegationReward",
         "@id": "actionWithdrawDelegationReward",
         "title": "Withdraw Delegation Reward",

--- a/src/common/components/ControlPanel/schema/Oracle.schema.json
+++ b/src/common/components/ControlPanel/schema/Oracle.schema.json
@@ -173,6 +173,29 @@
         ]
       },
       {
+        "@type": "Redelegate",
+        "@id": "actionRedelegate",
+        "title": "Redelegate",
+        "tooltip": "Redelegate",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "redelegate"
+          }
+        ]
+      },
+      {
         "@type": "Buy",
         "@id": "actionBuy",
         "title": "Buy",

--- a/src/common/components/ControlPanel/schema/Project.schema.json
+++ b/src/common/components/ControlPanel/schema/Project.schema.json
@@ -242,6 +242,29 @@
         ]
       },
       {
+        "@type": "Redelegate",
+        "@id": "actionRedelegate",
+        "title": "Redelegate",
+        "tooltip": "Redelegate",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "redelegate"
+          }
+        ]
+      },
+      {
         "@type": "Buy",
         "@id": "actionBuy",
         "title": "Buy",

--- a/src/common/components/ControlPanel/schema/Project.schema.json
+++ b/src/common/components/ControlPanel/schema/Project.schema.json
@@ -334,6 +334,29 @@
         ]
       },
       {
+        "@type": "ModifyWithdrawAddress",
+        "@id": "actionModifyWithdrawAddress",
+        "title": "Modify Withdraw Address",
+        "tooltip": "Modify Withdraw Address",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "modifywithdrawaddress"
+          }
+        ]
+      },
+      {
         "@type": "WithdrawDelegationReward",
         "@id": "actionWithdrawDelegationReward",
         "title": "Withdraw Delegation Reward",

--- a/src/common/components/ControlPanel/schema/Template.schema.json
+++ b/src/common/components/ControlPanel/schema/Template.schema.json
@@ -288,6 +288,29 @@
         ]
       },
       {
+        "@type": "ModifyWithdrawAddress",
+        "@id": "actionModifyWithdrawAddress",
+        "title": "Modify Withdraw Address",
+        "tooltip": "Modify Withdraw Address",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "modifywithdrawaddress"
+          }
+        ]
+      },
+      {
         "@type": "WithdrawDelegationReward",
         "@id": "actionWithdrawDelegationReward",
         "title": "Withdraw Delegation Reward",

--- a/src/common/components/ControlPanel/schema/Template.schema.json
+++ b/src/common/components/ControlPanel/schema/Template.schema.json
@@ -196,6 +196,29 @@
         ]
       },
       {
+        "@type": "Redelegate",
+        "@id": "actionRedelegate",
+        "title": "Redelegate",
+        "tooltip": "Redelegate",
+        "icon": "Vote",
+        "iconColor": "#49BFE0",
+        "endpoint": "#",
+        "accessToken": null,
+        "permissions": [
+          {
+            "credential": null,
+            "role": "user"
+          }
+        ],
+        "data": null,
+        "parameters": [
+          {
+            "name": "intent",
+            "value": "redelegate"
+          }
+        ]
+      },
+      {
         "@type": "Buy",
         "@id": "actionBuy",
         "title": "Buy",

--- a/src/common/utils/keplr.ts
+++ b/src/common/utils/keplr.ts
@@ -7,7 +7,7 @@ import { MsgDelegate } from "cosmjs-types/cosmos/staking/v1beta1/tx";
 import { MsgVote } from 'cosmjs-types/cosmos/gov/v1beta1/tx';
 import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx';
 import { MsgDeposit } from 'cosmjs-types/cosmos/gov/v1beta1/tx';
-import { MsgWithdrawDelegatorReward } from 'cosmjs-types/cosmos/distribution/v1beta1/tx'
+import { MsgWithdrawDelegatorReward, MsgSetWithdrawAddress } from 'cosmjs-types/cosmos/distribution/v1beta1/tx'
 
 declare const window: any
 
@@ -141,6 +141,8 @@ export const initStargateClient = async (offlineSigner) => {
   registry.register("/cosmos.bank.v1beta1.MsgSend", MsgSend);
   registry.register("/cosmos.gov.v1beta1.MsgDeposit", MsgDeposit);
   registry.register("/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward", MsgWithdrawDelegatorReward);
+  registry.register("/cosmos.distribution.v1beta1.MsgSetWithdrawAddress", MsgSetWithdrawAddress);
+  
   const options = { registry: registry };
 
   const cosmJS = await SigningStargateClient.connectWithSigner(

--- a/src/common/utils/keysafe.ts
+++ b/src/common/utils/keysafe.ts
@@ -10,15 +10,13 @@ export const broadCastMessage = (
   userAccountNumber,
   msg,
   memo = '',
+  fee,
   callback,
 ): void => {
   const payload = {
     msgs: [msg],
     chain_id: process.env.REACT_APP_CHAIN_ID,
-    fee: {
-      amount: [{ amount: String(5000), denom: 'uixo' }],
-      gas: String(200000),
-    },
+    fee,
     memo,
     account_number: String(userAccountNumber),
     sequence: String(userSequence),


### PR DESCRIPTION
## Scope

## Work Done
- Modify Withdraw Address Button on Actions panel
- Modify Withdraw Address Modal integration
- MsgModifyWithdrawAddress messaging for both Keplr and Keysafe

## Steps to Test
- Clicking button on Actions Panel and do action on popup modal
- To check, `/cosmos/distribution/v1beta1/delegators/{delegator_address}/withdraw_address`

## Screenshots
![image](https://user-images.githubusercontent.com/50171204/136594516-dcc1767a-b944-4260-ab65-acc4368b0c13.png)
