### PR TITLE
Launchpad fix display of Overview images

### DIFF
--- a/src/common/components/Modal/Modal.styles.ts
+++ b/src/common/components/Modal/Modal.styles.ts
@@ -5,7 +5,7 @@ export const ModalWrapper = styled.div`
   position: absolute;
   top: 50%;
   left: 0;
-  z-index: 10;
+  z-index: 1000;
   background: #f7f8f9;
   min-width: 320px;
   min-height: 50vh;

--- a/src/common/components/Modal/Modal.tsx
+++ b/src/common/components/Modal/Modal.tsx
@@ -21,22 +21,25 @@ const Modal: React.FunctionComponent<Props> = ({
   resetText,
   onSubmit,
   onCancel,
-  onReset
+  onReset,
 }) => {
   return (
-    <ModalWrapper style={style}>
+    <ModalWrapper
+      style={style}
+      data-rbd-drag-handle-draggable-id="gibberish"
+      data-rbd-drag-handle-context-id={0}
+    >
       <div>{children}</div>
       <div className="button-wrapper">
         <button type="button" onClick={onCancel}>
           {cancelText}
         </button>
         <div>
-          {
-            resetText &&
-              <button type="button" onClick={onReset} className="mr-2">
-                {resetText}
-              </button>
-          }
+          {resetText && (
+            <button type="button" onClick={onReset} className="mr-2">
+              {resetText}
+            </button>
+          )}
           <button
             type="button"
             className="submit"

--- a/src/modules/Entities/CreateEntity/CreateEntityPageContent/components/BodyContentCard/BodyContentCard.tsx
+++ b/src/modules/Entities/CreateEntity/CreateEntityPageContent/components/BodyContentCard/BodyContentCard.tsx
@@ -48,7 +48,7 @@ const BodyContentCard: React.FunctionComponent<Props> = React.forwardRef(
         'ui:widget': customControls['imageupload'],
         'ui:uploading': uploadingImage,
         'ui:maxDimension': 480,
-        'ui:previewWidth': 480,
+        'ui:previewWidth': '100%',
         'ui:aspect': 16 / 9,
         'ui:circularCrop': false,
       },

--- a/src/modules/Entities/CreateEntity/CreateEntityPageContent/components/BodyContentCard/BodyContentCard.tsx
+++ b/src/modules/Entities/CreateEntity/CreateEntityPageContent/components/BodyContentCard/BodyContentCard.tsx
@@ -49,7 +49,7 @@ const BodyContentCard: React.FunctionComponent<Props> = React.forwardRef(
         'ui:uploading': uploadingImage,
         'ui:maxDimension': 480,
         'ui:previewWidth': 480,
-        'ui:aspect': 1,
+        'ui:aspect': 16 / 9,
         'ui:circularCrop': false,
       },
       title: {

--- a/src/modules/Entities/SelectedEntity/EntityOverview/components/BodyContentCard/BodyContentCard.styles.ts
+++ b/src/modules/Entities/SelectedEntity/EntityOverview/components/BodyContentCard/BodyContentCard.styles.ts
@@ -3,27 +3,21 @@ import { deviceWidth } from 'lib/commonData'
 import { SectionContainer } from '../PageContent/PageContent.styles'
 
 export const Container = styled(SectionContainer)`
-  display: flex;
-  justify-content: center;
-  flex-flow: row wrap;
-  img,
+  min-height: 350px;
+  display: inline-block;
+  width: 100%;
+
   p {
-    flex: 1 1 auto;
-    width: 100%;
+    float: none;
   }
   img {
-    height: intrinsic;
-    object-fit: cover;
-    margin-bottom: 1rem;
+    float: left;
+    width: 50%;
   }
   @media (min-width: ${deviceWidth.tablet}px) {
     img {
       width: 50%;
-      margin-bottom: 0;
-    }
-    p.content {
-      width: calc(50% - 1.35rem);
-      margin-left: 1.25rem;
+      margin-right: 1rem;
     }
   }
 `

--- a/src/modules/Entities/SelectedEntity/EntityOverview/components/BodyContentCard/BodyContentCard.styles.ts
+++ b/src/modules/Entities/SelectedEntity/EntityOverview/components/BodyContentCard/BodyContentCard.styles.ts
@@ -6,7 +6,6 @@ export const Container = styled(SectionContainer)`
   min-height: 350px;
   display: inline-block;
   width: 100%;
-
   p {
     float: none;
   }


### PR DESCRIPTION
## Scope
https://ixo.youtrack.cloud/issue/WEB-59

## Work Done
- In Create Entity when images are uploaded for Main Section Card, ensure that the image crop is the correct dimension to match the display size and ratio
- When uploading an image for Main Section Card, enforce a minimum image height that is equal to the height of the display frame in Overview.
- In Overview display, set the maximum frame height for the Main Section Card image to the default and don't allow this to stretch and distort. Text should overflow around the bottom of the image if there is more text than the max height of the image.

## Steps to Test

## Screenshots
![image](https://user-images.githubusercontent.com/64268193/161850538-2e5806e9-033e-431f-9373-1feae417e6b7.png)
