### PR TITLE
Improved UX for Bonds Dashboard Navigation

### DIFF
--- a/src/common/components/Bonds/BondsSummaryHeader/Header.tsx
+++ b/src/common/components/Bonds/BondsSummaryHeader/Header.tsx
@@ -45,8 +45,6 @@ class Header extends Component<any, HeaderState> {
     const { activeBond, selectedHeader, setSelectedHeader } = this.props
     const balance = tokenBalance(this.props.account.balances, activeBond.symbol)
 
-    const { allowReserveWithdrawals } = activeBond
-
     const myStakeInfo = `${(
       (minimalDenomToDenom(balance.denom, balance.amount) /
         minimalDenomToDenom(
@@ -120,7 +118,7 @@ class Header extends Component<any, HeaderState> {
           priceColor="#39C3E6"
           setActiveHeaderItem={(): void => setSelectedHeader('reserve')}
           selected={selectedHeader === 'reserve'}
-          to={allowReserveWithdrawals}
+          to={true}
         />
         <HeaderItem
           title="Alpha"

--- a/src/common/components/Bonds/BondsSummaryHeader/SummaryCard/SummaryCard.styles.ts
+++ b/src/common/components/Bonds/BondsSummaryHeader/SummaryCard/SummaryCard.styles.ts
@@ -1,17 +1,18 @@
-import styled from "styled-components";
-import { deviceWidth } from "../../../../../lib/commonData";
+import styled from 'styled-components'
+import { deviceWidth } from '../../../../../lib/commonData'
 
 interface PriceProps {
-  priceColor: string;
+  priceColor: string
 }
 
 interface TokenProps {
-  backgroundColor: string;
+  backgroundColor: string
 }
 
 interface StyledHeaderItemProps {
-  selected: boolean;
-  activeColor: string;
+  selected: boolean
+  isActiveCursor: boolean
+  activeColor: string
 }
 
 export const StyledHeaderItem = styled.div<StyledHeaderItemProps>`
@@ -30,13 +31,14 @@ export const StyledHeaderItem = styled.div<StyledHeaderItemProps>`
   margin-right: 1.25em;
   padding: 1em;
   font-size: 0.75rem;
-  font-family: "Roboto Condensed", sans-serif;
+  font-family: 'Roboto Condensed', sans-serif;
   font-weight: normal;
   color: white;
-  cursor: pointer;
+  cursor: ${(props: any): string =>
+    props.isActiveCursor ? 'pointer' : 'auto'};
   justify-content: space-around;
   box-shadow: ${(props: any): string =>
-    props.selected ? "0px 0px 10px rgba(16, 117, 145, 0.3)" : ""};
+    props.selected ? '0px 0px 10px rgba(16, 117, 145, 0.3)' : ''};
   &:last-child {
     margin: 0;
   }
@@ -54,7 +56,7 @@ export const StyledHeaderItem = styled.div<StyledHeaderItemProps>`
     margin-left: 0.5rem;
     margin-right: 1rem;
   }
-`;
+`
 
 export const Title = styled.div`
   font-size: 0.625rem;
@@ -62,34 +64,34 @@ export const Title = styled.div`
   @media (min-width: 480px) {
     font-size: 1.1875rem;
   }
-`;
+`
 
 export const Price = styled.div<PriceProps>`
   font-size: 1.5rem;
   line-height: 1.25;
   font-weight: bold;
   color: ${(props: any): string =>
-    props.priceColor ? props.priceColor : "white"};
+    props.priceColor ? props.priceColor : 'white'};
   @media (min-width: 480px) {
     font-size: 1.6875rem;
   }
-`;
+`
 
 export const AdditionalInfo = styled.div`
-  font-family: "Roboto" sans-serif;
-`;
+  font-family: 'Roboto' sans-serif;
+`
 
 export const ValueContainer = styled.div`
   display: flex;
   flex-direction: column;
   padding: 0.125rem;
   flex-grow: 1;
-`;
+`
 
 export const Token = styled.div<TokenProps>`
   text-align: center;
   background: ${(props: any): string =>
-    props.backgroundColor ? props.backgroundColor : "#73ce99"};
+    props.backgroundColor ? props.backgroundColor : '#73ce99'};
   margin-left: 0.5rem;
   margin-right: 1rem;
   display: flex;
@@ -108,7 +110,7 @@ export const Token = styled.div<TokenProps>`
       font-size: 1rem;
     }
   }
-`;
+`
 
 export const DotsContainer = styled.div`
   position: absolute;

--- a/src/common/components/Bonds/BondsSummaryHeader/SummaryCard/SummaryCard.tsx
+++ b/src/common/components/Bonds/BondsSummaryHeader/SummaryCard/SummaryCard.tsx
@@ -8,17 +8,21 @@ import {
   AdditionalInfo,
   DotsContainer,
 } from './SummaryCard.styles'
-import { thousandSeparator } from 'common/utils/formatters'
 import IxoBlue from 'assets/icons/IxoBlue'
 import ThreeDot from 'assets/icons/ThreeDot'
+import { nFormatter } from 'common/utils/currency.utils'
 
 export default class HeaderItem extends Component<any> {
   render(): JSX.Element {
+    const { value } = this.props
+    const formattedValue = nFormatter(value, 2)
+
     return (
       <StyledHeaderItem
         selected={this.props.selected}
         onClick={this.props.setActiveHeaderItem}
         activeColor={this.props.priceColor}
+        isActiveCursor={this.props.to}
       >
         {this.props.isAlpha && <IxoBlue />}
         {this.props.tokenType && (
@@ -29,9 +33,7 @@ export default class HeaderItem extends Component<any> {
 
         <ValueContainer>
           <Title>{this.props.title}</Title>
-          <Price priceColor={this.props.priceColor}>
-            {thousandSeparator(this.props.value)}
-          </Price>
+          <Price priceColor={this.props.priceColor}>{formattedValue}</Price>
           <AdditionalInfo>{this.props.additionalInfo}</AdditionalInfo>
         </ValueContainer>
 


### PR DESCRIPTION
## Scope
WEB-68: https://ixo.youtrack.cloud/issue/WEB-68

## Work Done
- The selector mouse pointer should only become active when the user hovers over a headline card that has a view available (currently this is Last Price and Reserve Funds)
- Reserve Funds (and in future, any card that has a view available) should have the 3-dots icon displayed just as it currently appears on the Last Price card,
- Test to ensure that large numbers > 100,000 are converted to short form. For example Capital Raised = 23'456'230.16 > 23.456 M

## Steps to Test

## Screenshots
