### PR TITLE
fix(311): remove library word in Protocol explorer subtitle

### DIFF
--- a/configs/launchpad/config.json
+++ b/configs/launchpad/config.json
@@ -2682,7 +2682,7 @@
       "color": "transparent",
       "image": "https://raw.githubusercontent.com/ixofoundation/ixo-webclient/dev/src/assets/images/header-overrides/relayerlaunchpad.png",
       "title": "Launchpad",
-      "subTitle": "Protocol Library Explorer",
+      "subTitle": "Protocol Explorer",
       "indicators": [
         {
           "@type": "Indicator",

--- a/configs/testzone/config.json
+++ b/configs/testzone/config.json
@@ -3528,7 +3528,7 @@
       "color": "transparent",
       "image": "https://raw.githubusercontent.com/ixofoundation/ixo-webclient/dev/src/assets/images/header-overrides/ixoworld_hero.png",
       "title": "Test Zone",
-      "subTitle": "Protocol Library Explorer",
+      "subTitle": "Protocol Explorer",
       "indicators": [
         {
           "@type": "Indicator",


### PR DESCRIPTION
## Scope

## Work Done

## Steps to Test

## Screenshots
