### PR TITLE
fix: adding link to button on splash page and fixing button styles when hovering

### DIFF
--- a/src/pages/splash/SplashLandingSection/SplashLandingSection.components.tsx
+++ b/src/pages/splash/SplashLandingSection/SplashLandingSection.components.tsx
@@ -156,6 +156,8 @@ export const GradientButton = styled.a`
 
   :hover {
     box-shadow: 2px 1000px 1px #142547 inset;
+    text-decoration: none;
+    color: #fff;
   }
 
   @media (max-width: ${deviceWidth.tablet}px) {

--- a/src/pages/splash/SplashLandingSection/SplashLandingSection.tsx
+++ b/src/pages/splash/SplashLandingSection/SplashLandingSection.tsx
@@ -67,7 +67,13 @@ const SplashLandingSection: FC = () => {
           <SubHeading>Bring Web3 to Life</SubHeading>
         </TopContainer>
         <BottomContainer>
-          <GradientButton>PREPARE TO LAUNCH</GradientButton>
+          <GradientButton
+            href="https://airtable.com/shrl3vCq3yIZZHNF5"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            PREPARE TO LAUNCH
+          </GradientButton>
           <div>
             <AppLabel>
               Get your <strong>Earth X</strong> Mobile Wallet


### PR DESCRIPTION
## Scope
Add link to the button on the splash screen's landing section

## Work Done
Added the link to the button on the splash screen's landing section and fixed the styles of the button when hovering over it.

## Steps to Test
Click the link on the splash screen's landing section

## Screenshots
![image](https://user-images.githubusercontent.com/65312389/191939304-772be291-0775-4839-81b1-483cae85800b.png)
