### PR TITLE
feat(WEB-381): creating hook to read query params and using query params to display entities on explore page on load

### DIFF
--- a/src/common/hooks/index.tsx
+++ b/src/common/hooks/index.tsx
@@ -1,11 +1,12 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
+import { useHistory, useLocation } from 'react-router-dom'
 
-interface HooksReturnType {
+interface UseWindowSizeHooksReturnType {
   width: number
   height: number
 }
 
-function useWindowSize(): HooksReturnType {
+function useWindowSize(): UseWindowSizeHooksReturnType {
   // Initialize state with undefined width/height so server and client renders match
   // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
   const [windowSize, setWindowSize] = useState({
@@ -36,4 +37,38 @@ function useWindowSize(): HooksReturnType {
   return windowSize
 }
 
-export { useWindowSize }
+interface UseQueryHookReturnType {
+  query: URLSearchParams
+  getQuery: Function
+}
+
+function useQuery(): UseQueryHookReturnType {
+  const history = useHistory()
+  const { search } = useLocation()
+
+  const queryParams = useMemo(
+    (): URLSearchParams => new URLSearchParams(search),
+    [search],
+  )
+
+  const getQuery = (
+    searchParam: string,
+    clearSearchParam?: boolean,
+  ): string | undefined => {
+    if (!queryParams.has(searchParam)) return undefined
+
+    const query = queryParams.get(searchParam)
+
+    if (clearSearchParam) {
+      queryParams.delete(searchParam)
+
+      history.replace({ search: queryParams.toString() })
+    }
+
+    return query
+  }
+
+  return { query: queryParams, getQuery }
+}
+
+export { useWindowSize, useQuery }

--- a/src/modules/Entities/EntitiesExplorer/EntitiesExplorer.container.tsx
+++ b/src/modules/Entities/EntitiesExplorer/EntitiesExplorer.container.tsx
@@ -46,7 +46,25 @@ import * as accountSelectors from 'modules/Account/Account.selectors'
 import detectGrid from 'detect-grid'
 import { useEffect, useState } from 'react'
 import { EntityCollection } from './components'
+import { useQuery } from 'common/hooks'
 // import { checkIsLaunchpadFromApiListedEntityData } from '../Entities.utils'
+
+const entityFilters = {
+  project: 'Project',
+  projects: 'Project',
+  oracle: 'Oracle',
+  oracles: 'Oracle',
+  investment: 'Investment',
+  investments: 'Investment',
+  dao: 'Dao',
+  daos: 'Dao',
+  protocol: 'Template',
+  protocols: 'Template',
+  template: 'Template',
+  templates: 'Template',
+  asset: 'Asset',
+  assets: 'Asset',
+}
 
 export interface Props extends RouteProps {
   match: any
@@ -105,6 +123,7 @@ const EntitiesExplorer: React.FunctionComponent<Props> = (props) => {
   const [itemOffset, setItemOffset] = useState(0)
   const [itemsPerPage, setItemsPerPage] = useState(9)
   const [selected, setSelected] = useState(0)
+  const { getQuery } = useQuery()
 
   const resetWithDefaultViewFilters = (): void => {
     props.handleResetFilters()
@@ -324,6 +343,13 @@ const EntitiesExplorer: React.FunctionComponent<Props> = (props) => {
 
   useEffect(() => {
     props.handleGetEntities()
+
+    let filter: string | undefined = getQuery('filter', true)
+    filter = filter && filter.length > 0 ? filter.toLowerCase() : filter
+
+    if (filter && Object.keys(entityFilters).includes(filter)) {
+      props.handleChangeEntitiesType(EntityType[entityFilters[filter]])
+    }
     // eslint-disable-next-line
   }, [])
 


### PR DESCRIPTION
## Scope
Create a way to directly access any entity on Explorer via URL route

## Work Done
Create a query params hook and used it to allow the Explorer to render any entity based on the initial query params. 

## Steps to Test
Go to `/explore?filter=<entity>` where `<entity>` can be any of the following:
- Project
- Oracle
- Investment
- Dao
- Protocol/Template
- Asset

Note that `<entity>` is not case sensitive and can be plural (e.g. `/explore?filter=ASSET` or `/explore?filter=daos`)
The explorer will load with the queried entity section and then clear the query parameter once loaded.

## Screenshots
