### PR TITLE
fix(WEB-396): minor wording changes on splash page and altering splash partner image rendering

### DIFF
--- a/src/pages/splash/SplashLandingSection/SplashLandingSection.components.tsx
+++ b/src/pages/splash/SplashLandingSection/SplashLandingSection.components.tsx
@@ -183,6 +183,15 @@ export const GradientAppButton = styled(GradientButton)<GradientAppButtonProps>`
   margin: 0;
   margin-right: ${/* eslint-disable-line */ (props) =>
     props.marginRight || 0}px;
+  // remove these once app links are ready ==========
+  cursor: not-allowed;
+
+  &:hover {
+    box-shadow: 2px 1000px 1px #000 inset;
+    text-decoration: none;
+    color: initial;
+  }
+  // ================================================
 
   @media (max-width: ${deviceWidth.desktop}px) {
     padding: 0;

--- a/src/pages/splash/SplashLandingSection/SplashLandingSection.tsx
+++ b/src/pages/splash/SplashLandingSection/SplashLandingSection.tsx
@@ -72,25 +72,29 @@ const SplashLandingSection: FC = () => {
             target="_blank"
             rel="noopener noreferrer"
           >
-            PREPARE TO LAUNCH
+            APPLY TO LAUNCH
           </GradientButton>
           <div>
             <AppLabel>
-              Get your <strong>Earth X</strong> Mobile Wallet
+              Get your <strong>Impact Wallet</strong>
+              {'   '}
+              <small>(coming soon)</small>
             </AppLabel>
             <FlexWrapper>
               <GradientAppButton
                 marginRight={12}
-                href="https://play.google.com/store/apps/details?id=com.ixo&hl=en"
-                target="_blank"
-                rel="noopener noreferrer"
+                // href="https://play.google.com/store/apps/details?id=com.ixo&hl=en"
+                // target="_blank"
+                // rel="noopener noreferrer"
+                title="Coming Soon"
               >
                 <AppImg src={googlePlay} alt="Get it on Google Play" />
               </GradientAppButton>
               <GradientAppButton
-                href="https://itunes.apple.com/za/app/ixo/id1441394401?mt=8"
-                target="_blank"
-                rel="noopener noreferrer"
+                // href="https://itunes.apple.com/za/app/ixo/id1441394401?mt=8"
+                // target="_blank"
+                // rel="noopener noreferrer"
+                title="Coming Soon"
               >
                 <AppImg src={appleStore} alt="Download on the App Store" />
               </GradientAppButton>

--- a/src/pages/splash/SplashLaunchSection/SplashLaunchSection.tsx
+++ b/src/pages/splash/SplashLaunchSection/SplashLaunchSection.tsx
@@ -151,7 +151,7 @@ export const SplashLaunchSection: FC = () => {
                   <br />
                   <br />
                   Impact Tokens can be sold directly, or traded through
-                  cross-chain decentralised Impact Exchanges.
+                  interchain decentralised Impact Exchanges.
                   <br />
                   <br />
                   <em>

--- a/src/pages/splash/SplashPartnersSection/SplashPartnersSection.tsx
+++ b/src/pages/splash/SplashPartnersSection/SplashPartnersSection.tsx
@@ -14,6 +14,10 @@ import { partners as PARTNERS } from '../splash-config.json'
 interface Props {}
 
 const SplashPartnersSection: FunctionComponent<Props> = () => {
+  const isImageExternalLink = (imageSource: string): boolean => {
+    return imageSource.trim().startsWith('http')
+  }
+
   return (
     <ContentContainer>
       <CollectionContainer>
@@ -30,7 +34,11 @@ const SplashPartnersSection: FunctionComponent<Props> = () => {
                   backgroundColor={sponsor.color}
                 >
                   <CardImage
-                    src={require(`assets/images/splash/partners/${sponsor.image}`)}
+                    src={
+                      isImageExternalLink(sponsor.image)
+                        ? sponsor.image
+                        : require(`assets/images/splash/partners/${sponsor.image}`)
+                    }
                     alt={sponsor.title}
                     loading="lazy"
                   />

--- a/src/pages/splash/splash-config.json
+++ b/src/pages/splash/splash-config.json
@@ -355,7 +355,7 @@
     {
       "title": "Financial Times",
       "color": "#000000",
-      "image": "financial-times-sponsor.png",
+      "image": "https://images.unsplash.com/photo-1664332817741-7c9ab631a9be?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1632&q=80",
       "url": "https://www.ft.com/content/7e5ad13a-b107-11e8-87e0-d84e0d934341"
     },
     {


### PR DESCRIPTION
## Scope
WEB-396: Launchpad Splashpage minor edits
WEB-398: Splash page - Coming soon. on the app stores.

## Work Done
Edited the wording on the splash page. Made app store buttons unclickable with "coming soon" title.

## Steps to Test
Check splash page

## Screenshots
