### PR TITLE
fix(371): disable claim dashboard when clicking headline header

### DIFF
--- a/src/modules/Entities/SelectedEntity/EntityImpact/Overview/components/Dashboard/Dashboard.tsx
+++ b/src/modules/Entities/SelectedEntity/EntityImpact/Overview/components/Dashboard/Dashboard.tsx
@@ -252,7 +252,13 @@ const Dashboard: React.FunctionComponent<Props> = ({
                     <img alt="" src={require('assets/img/sidebar/claim.svg')} />
                     Headline Claims
                   </div>
-                  <WrappedLink to={`/projects/${did}/detail/claims`}>
+                  <WrappedLink
+                    to={
+                      canViewClaim
+                        ? `/projects/${did}/detail/claims`
+                        : undefined
+                    }
+                  >
                     <i className="icon-expand" />
                   </WrappedLink>
                 </SectionHeader>


### PR DESCRIPTION
## Scope

## Work Done

## Steps to Test

## Screenshots
