### PR TITLE
Fix/web 394

### DIFF
--- a/src/common/components/Header/HeaderLeft/HeaderLeft.tsx
+++ b/src/common/components/Header/HeaderLeft/HeaderLeft.tsx
@@ -51,17 +51,10 @@ export const HeaderLeft: React.FC<ParentProps> = (props) => {
     return headerUIConfig.link
   }, [headerUIConfig])
 
-  const splashIsRootRoute = React.useMemo(() => {
-    if (!entityTypeMap) {
-      return false
-    }
-    const { route } = entityTypeMap
-    if (!route) {
-      return false
-    }
-    const { splashIsRootRoute } = route
-    return !!splashIsRootRoute
-  }, [entityTypeMap])
+  const splashIsRootRoute = React.useMemo(
+    () => !!entityTypeMap?.route?.splashIsRootRoute,
+    [entityTypeMap],
+  )
 
   const getMenuItems = (inHeader: boolean): JSX.Element => {
     if (inHeader) {

--- a/src/modules/Entities/CreateEntity/CreateEntityFinal/CreateEntityFinal.container.tsx
+++ b/src/modules/Entities/CreateEntity/CreateEntityFinal/CreateEntityFinal.container.tsx
@@ -28,6 +28,11 @@ const CreateEntityFinal: React.FunctionComponent<Props> = ({
   const entityTypeMap = useSelector(selectEntityConfig)
   const entityTitle = entityTypeMap[entityType].title
 
+  const splashIsRootRoute = React.useMemo(
+    () => !!entityTypeMap?.route?.splashIsRootRoute,
+    [entityTypeMap],
+  )
+
   return (
     <Container>
       {creating && (
@@ -45,7 +50,11 @@ const CreateEntityFinal: React.FunctionComponent<Props> = ({
         >
           <a
             className="close-button"
-            href={`/entities/select?type=${entityType}&amp;sector=all`}
+            href={
+              splashIsRootRoute
+                ? `/explore?filter=${entityType}`
+                : `/filter=${entityType}`
+            }
           >
             View in Explorer
           </a>

--- a/src/modules/Entities/SelectedEntity/EntityEdit/EditEntityFinal/EditEntityFinal.container.tsx
+++ b/src/modules/Entities/SelectedEntity/EntityEdit/EditEntityFinal/EditEntityFinal.container.tsx
@@ -28,6 +28,11 @@ const EditEntityFinal: React.FunctionComponent<Props> = ({
   const entityTypeMap = useSelector(selectEntityConfig)
   const entityTitle = entityTypeMap[entityType].title
 
+  const splashIsRootRoute = React.useMemo(
+    () => !!entityTypeMap?.route?.splashIsRootRoute,
+    [entityTypeMap],
+  )
+
   return (
     <Container>
       {editing && (
@@ -45,7 +50,11 @@ const EditEntityFinal: React.FunctionComponent<Props> = ({
         >
           <a
             className="close-button"
-            href={`/entities/select?type=${entityType}&amp;sector=all&amp`}
+            href={
+              splashIsRootRoute
+                ? `/explore?filter=${entityType}`
+                : `/filter=${entityType}`
+            }
           >
             View in Explorer
           </a>

--- a/src/modules/Entities/SelectedEntity/EntityHero/EntityHero.tsx
+++ b/src/modules/Entities/SelectedEntity/EntityHero/EntityHero.tsx
@@ -74,17 +74,10 @@ const EntityHero: React.FunctionComponent<Props> = ({
     return ''
   }
 
-  const splashIsRootRoute = React.useMemo(() => {
-    if (!entityTypeMap) {
-      return false
-    }
-    const { route } = entityTypeMap
-    if (!route) {
-      return false
-    }
-    const { splashIsRootRoute } = route
-    return !!splashIsRootRoute
-  }, [entityTypeMap])
+  const splashIsRootRoute = React.useMemo(
+    () => !!entityTypeMap?.route?.splashIsRootRoute,
+    [entityTypeMap],
+  )
 
   const renderNavs = (): JSX.Element => {
     return (

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -39,17 +39,10 @@ const App: React.FunctionComponent<Props> = ({ toggleAssistant }) => {
     // eslint-disable-next-line
   }, [location])
 
-  const splashIsRootRoute = React.useMemo(() => {
-    if (!entityTypeMap) {
-      return false
-    }
-    const { route } = entityTypeMap
-    if (!route) {
-      return false
-    }
-    const { splashIsRootRoute } = route
-    return !!splashIsRootRoute
-  }, [entityTypeMap])
+  const splashIsRootRoute = React.useMemo(
+    () => !!entityTypeMap?.route?.splashIsRootRoute,
+    [entityTypeMap],
+  )
 
   return (
     <Fragment>


### PR DESCRIPTION
## Scope
WEB-394: After creation, the View in Explorer points to incorrect page

## Work Done
Altered the "View in Explorer" to navigate to the explore page (with the filter of the entity type that was created) and cleaned up the plash page routing logic.

## Steps to Test
Create an entity and click on "View in Explorer"

## Screenshots
