### PR TITLE
fix(WEB-412): splash page sdg of ixo point to ixo.world

### DIFF
--- a/src/pages/splash/splash-config.json
+++ b/src/pages/splash/splash-config.json
@@ -124,7 +124,7 @@
       "class": "icon-logo-ixo",
       "title": "The new world of IMPACT",
       "bgColor": "#00D2FF",
-      "url": "/"
+      "url": "https://ixo.world"
     }
   ],
   "features": [


### PR DESCRIPTION
## Scope
WEB-412: SDG image of ixo points to Splash page

## Work Done
Updated the link of the ixo SDG on splash page

## Steps to Test
Navigate to the splash page and click on ixo SDG (should be navigated to http://ix

## Screenshots
![image](https://user-images.githubusercontent.com/65312389/193252584-cac403ae-309d-45f6-a1c6-63ac5f9ec66e.png)
