### PR TITLE
fix(WEB-424): removing lorem ipsum from 'create protocol' flow

### DIFF
--- a/src/modules/Entities/CreateEntity/CreateSelectTemplate/CreateSelectTemplate.container.tsx
+++ b/src/modules/Entities/CreateEntity/CreateSelectTemplate/CreateSelectTemplate.container.tsx
@@ -50,7 +50,7 @@ class CreateSelectTemplate extends CreateEntityBase<any> {
             ? `Create ${articleFormat(templateType)} ${templateType} Protocol`
             : `Create a Protocol`
         }
-        description="Lorem ipsum"
+        // description="Lorem ipsum"
         keyword="template"
       >
         <SelectTemplateCard


### PR DESCRIPTION
## Scope
WEB(424): Remove the Lorem Ipsum wording on the first page - should be empty.

## Work Done
Removed "lorem ipsum" from 'Create Protocol' flow

## Steps to Test
Start the process to create a protocol

## Screenshots
