### PR TITLE
Styles/web

### DIFF
--- a/src/assets/icons/MobileSwipe.tsx
+++ b/src/assets/icons/MobileSwipe.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+const MobileSwipe = (props: any): JSX.Element => {
+  return (
+    <svg
+      width={props.width || 18}
+      viewBox="0 0 36 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M22.0231 6.27794C21.2167 4.823 19.4306 4.3245 18.0339 5.16451C16.6372 6.00452 16.1586 7.86495 16.965 9.31989"
+        stroke={props.stroke || 'white'}
+        strokeWidth="1.5"
+      />
+      <path
+        d="M15.2858 6.27794C14.4794 4.823 12.6933 4.3245 11.2966 5.16451C9.89986 6.00452 9.4213 7.86495 10.2277 9.31989"
+        stroke={props.stroke || 'white'}
+        strokeWidth="1.5"
+      />
+      <path
+        d="M10.2275 9.31989L16.3547 20.3565"
+        stroke={props.stroke || 'white'}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M15.2852 6.27795L22.8753 20.3291"
+        stroke={props.stroke || 'white'}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M22.0225 6.27795L29.7794 20.3565"
+        stroke={props.stroke || 'white'}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M4.61502 7.06989L1.50935 10.305C1.31811 10.5042 1.31811 10.8271 1.50935 11.0263L4.61502 14.2614"
+        stroke={props.stroke || 'white'}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M31.385 14.2614L34.4906 11.0263C34.6819 10.8271 34.6819 10.5042 34.4906 10.305L31.385 7.06989"
+        stroke={props.stroke || 'white'}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+export default MobileSwipe

--- a/src/common/components/ControlPanel/Apps/Apps.tsx
+++ b/src/common/components/ControlPanel/Apps/Apps.tsx
@@ -9,6 +9,12 @@ import GitCoin from './GitCoin/GitCoin'
 import DaoStack from './DaoStack/DaoStack'
 import AddPlugin from './AddPlugin/AddPlugin'
 
+declare global {
+  interface Window {
+    MobileContext: boolean | undefined
+  }
+}
+
 interface Props {
   widget: Widget
   showMore: boolean
@@ -53,15 +59,13 @@ const Apps: React.FunctionComponent<Props> = ({
       </h4>
       <AppButtonsWrapper>
         {riotChatControl && (
-          <RiotChat buttonClassName="hide" control={riotChatControl} /> 
+          <RiotChat buttonClassName="hide" control={riotChatControl} />
         )}
-        {
-          gitCoinControl && (
-            <GitCoin buttonClassName="hide" control={gitCoinControl} />
+        {gitCoinControl && (
+          <GitCoin buttonClassName="hide" control={gitCoinControl} />
         )}
-        {
-          daoStackControl && (
-            <DaoStack buttonClassName="hide" control={daoStackControl} />
+        {daoStackControl && (
+          <DaoStack buttonClassName="hide" control={daoStackControl} />
         )}
         <AddPlugin buttonClassName="show" />
       </AppButtonsWrapper>

--- a/src/common/components/ControlPanel/Apps/Apps.tsx
+++ b/src/common/components/ControlPanel/Apps/Apps.tsx
@@ -11,7 +11,7 @@ import AddPlugin from './AddPlugin/AddPlugin'
 
 declare global {
   interface Window {
-    MobileContext: boolean | undefined
+    MobileContext: string | boolean | undefined
   }
 }
 

--- a/src/common/components/ControlPanel/ControlPanel.tsx
+++ b/src/common/components/ControlPanel/ControlPanel.tsx
@@ -30,6 +30,8 @@ interface State {
   showMoreConnections: boolean
 }
 
+const isViewedFromApp = !!window.MobileContext
+
 class ControlPanel extends React.Component<Props, State> {
   state = {
     showControlPanelMobile: false,
@@ -104,6 +106,9 @@ class ControlPanel extends React.Component<Props, State> {
       userDid,
       claims,
     } = this.props
+
+    if (isViewedFromApp) return null
+
     return (
       <>
         <MobileControlPanelToggle onClick={this.toggleShowControlPanel}>

--- a/src/common/components/ControlPanel/ControlPanel.tsx
+++ b/src/common/components/ControlPanel/ControlPanel.tsx
@@ -30,8 +30,6 @@ interface State {
   showMoreConnections: boolean
 }
 
-const isViewedFromApp = !!window.MobileContext
-
 class ControlPanel extends React.Component<Props, State> {
   state = {
     showControlPanelMobile: false,
@@ -107,7 +105,7 @@ class ControlPanel extends React.Component<Props, State> {
       claims,
     } = this.props
 
-    if (isViewedFromApp) return null
+    if (window.MobileContext) return null
 
     return (
       <>

--- a/src/common/components/ControlPanel/ControlPanel.tsx
+++ b/src/common/components/ControlPanel/ControlPanel.tsx
@@ -105,7 +105,8 @@ class ControlPanel extends React.Component<Props, State> {
       claims,
     } = this.props
 
-    if (window.MobileContext) return null
+    const isViewedFromApp = !!window.MobileContext
+    if (isViewedFromApp) return null
 
     return (
       <>

--- a/src/common/components/Widgets/WorldMap/WorldMap.styles.ts
+++ b/src/common/components/Widgets/WorldMap/WorldMap.styles.ts
@@ -1,6 +1,10 @@
 import styled from 'styled-components'
 
+import { deviceWidth } from 'lib/commonData'
+
 export const MapWrapper = styled.div`
+  position: relative;
+
   :hover {
     cursor: grab;
   }
@@ -14,5 +18,18 @@ export const MapWrapper = styled.div`
   }
   g.rsm-marker {
     outline-width: 0px;
+  }
+`
+
+export const MobileSwipeIconWrapper = styled.div`
+  pointer-events: none;
+  position: absolute;
+  bottom: 0;
+  right: 1px;
+  padding: 0;
+  margin: 0;
+
+  @media (min-width: ${deviceWidth.mobile}px) {
+    display: none;
   }
 `

--- a/src/common/components/Widgets/WorldMap/WorldMap.tsx
+++ b/src/common/components/Widgets/WorldMap/WorldMap.tsx
@@ -9,7 +9,8 @@ import {
   Lines,
   Line,
 } from 'react-simple-maps'
-import { MapWrapper } from './WorldMap.styles'
+import { MapWrapper, MobileSwipeIconWrapper } from './WorldMap.styles'
+import MobileSwipe from 'assets/icons/MobileSwipe'
 
 export class LatLng {
   coordinate = null
@@ -114,6 +115,9 @@ export class WorldMap extends React.Component<ParentProps> {
             </Lines>
           </ZoomableGroup>
         </ComposableMap>
+        <MobileSwipeIconWrapper>
+          <MobileSwipe width={36} />
+        </MobileSwipeIconWrapper>
       </MapWrapper>
     )
   }

--- a/src/modules/Entities/SelectedEntity/EntityImpact/Overview/components/Dashboard/Dashboard.styles.tsx
+++ b/src/modules/Entities/SelectedEntity/EntityImpact/Overview/components/Dashboard/Dashboard.styles.tsx
@@ -157,3 +157,33 @@ export const WrappedLink = styled(Link)`
     color: white;
   }
 `
+
+export const ScrollableButtons = styled.div`
+  width: 100%;
+  overflow-x: auto;
+  padding-bottom: 4px;
+
+  @media (max-width: ${deviceWidth.tablet}px) {
+    padding-bottom: 5px;
+  }
+
+  &::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  /* Track */
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  /* Handle */
+  &::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background: #0a3347;
+  }
+
+  /* Handle on hover */
+  &::-webkit-scrollbar-thumb:hover {
+    background: #143f54;
+  }
+`

--- a/src/modules/Entities/SelectedEntity/EntityImpact/Overview/components/Dashboard/Dashboard.tsx
+++ b/src/modules/Entities/SelectedEntity/EntityImpact/Overview/components/Dashboard/Dashboard.tsx
@@ -33,8 +33,6 @@ import {
 import ProjectGovernance from './ProjectGovernance'
 import Targets from './Targets'
 
-const isViewedFromApp = !!window.MobileContext
-console.log({ isViewedFromApp })
 export interface Props {
   did: string
   bondDid: string
@@ -74,6 +72,7 @@ const Dashboard: React.FunctionComponent<Props> = ({
   entityClaims,
   agents,
 }) => {
+  const isViewedFromApp = !!window.MobileContext
   const userRole = useSelector(selectUserRole)
   const [activeTabIndex, setActiveTabIndex] = useState(0)
   // const [successfulClaims, setSuccessfulClaims] = useState(0)

--- a/src/modules/Entities/SelectedEntity/EntityImpact/Overview/components/Dashboard/Dashboard.tsx
+++ b/src/modules/Entities/SelectedEntity/EntityImpact/Overview/components/Dashboard/Dashboard.tsx
@@ -28,6 +28,7 @@ import {
   ProgressContainer,
   SectionHeader,
   WrappedLink,
+  ScrollableButtons,
 } from './Dashboard.styles'
 import ProjectGovernance from './ProjectGovernance'
 import Targets from './Targets'
@@ -137,18 +138,20 @@ const Dashboard: React.FunctionComponent<Props> = ({
             }
           >
             <div className="d-flex justify-content-between w-100 mt-3 mb-2 flex-column flex-sm-row flex-wrap">
-              <ButtonSlider>
-                {entityClaims.map((claim, key) => (
-                  <Button
-                    type={ButtonTypes.dark}
-                    onClick={(): void => handleTabClick(key)}
-                    inactive={activeTabIndex !== key}
-                    key={key}
-                  >
-                    {claim.title}
-                  </Button>
-                ))}
-              </ButtonSlider>
+              <ScrollableButtons>
+                <ButtonSlider>
+                  {entityClaims.map((claim, key) => (
+                    <Button
+                      type={ButtonTypes.dark}
+                      onClick={(): void => handleTabClick(key)}
+                      inactive={activeTabIndex !== key}
+                      key={key}
+                    >
+                      {claim.title}
+                    </Button>
+                  ))}
+                </ButtonSlider>
+              </ScrollableButtons>
               <ClaimsTopLabels>
                 <p>Claims pending</p>
                 <p>Claims approved</p>

--- a/src/modules/Entities/SelectedEntity/EntityImpact/Overview/components/Dashboard/Dashboard.tsx
+++ b/src/modules/Entities/SelectedEntity/EntityImpact/Overview/components/Dashboard/Dashboard.tsx
@@ -33,6 +33,8 @@ import {
 import ProjectGovernance from './ProjectGovernance'
 import Targets from './Targets'
 
+const isViewedFromApp = !!window.MobileContext
+console.log({ isViewedFromApp })
 export interface Props {
   did: string
   bondDid: string
@@ -195,8 +197,8 @@ const Dashboard: React.FunctionComponent<Props> = ({
               title="Project Governance"
               link={true}
               gridHeight={gridSizes.standard}
-              path={`/projects/${did}/detail/governance`}
-              linkIcon={'icon-expand'}
+              path={!isViewedFromApp && `/projects/${did}/detail/governance`}
+              linkIcon={!isViewedFromApp && 'icon-expand'}
               titleIcon={
                 <img
                   alt=""
@@ -255,15 +257,17 @@ const Dashboard: React.FunctionComponent<Props> = ({
                     <img alt="" src={require('assets/img/sidebar/claim.svg')} />
                     Headline Claims
                   </div>
-                  <WrappedLink
-                    to={
-                      canViewClaim
-                        ? `/projects/${did}/detail/claims`
-                        : undefined
-                    }
-                  >
-                    <i className="icon-expand" />
-                  </WrappedLink>
+                  {!isViewedFromApp && (
+                    <WrappedLink
+                      to={
+                        canViewClaim
+                          ? `/projects/${did}/detail/claims`
+                          : undefined
+                      }
+                    >
+                      <i className="icon-expand" />
+                    </WrappedLink>
+                  )}
                 </SectionHeader>
                 <div className="pl-4">
                   <p>
@@ -294,9 +298,11 @@ const Dashboard: React.FunctionComponent<Props> = ({
                       />
                       Agents
                     </div>
-                    <WrappedLink to={`/projects/${did}/detail/agents`}>
-                      <i className="icon-expand" />
-                    </WrappedLink>
+                    {!isViewedFromApp && (
+                      <WrappedLink to={`/projects/${did}/detail/agents`}>
+                        <i className="icon-expand" />
+                      </WrappedLink>
+                    )}
                   </SectionHeader>
                   <div className="mt-2 mt-sm-4">
                     <div style={{ paddingLeft: '60px' }}>
@@ -366,7 +372,7 @@ const Dashboard: React.FunctionComponent<Props> = ({
             titleIcon={
               <img alt="" src={require('assets/img/sidebar/claim.svg')} />
             }
-            linkIcon={'icon-expand'}
+            linkIcon={!isViewedFromApp && 'icon-expand'}
             link={true}
           >
             <ProjectClaims

--- a/src/pages/splash/SplashLandingSection/SplashLandingSection.tsx
+++ b/src/pages/splash/SplashLandingSection/SplashLandingSection.tsx
@@ -62,7 +62,7 @@ const SplashLandingSection: FC = () => {
               eraseDelay={2000}
               showCursor
             />
-            <div className="sentence">LAUNCHPAD {window.MobileContext}</div>
+            <div className="sentence">LAUNCHPAD</div>
           </Heading>
           <SubHeading>Bring Web3 to Life</SubHeading>
         </TopContainer>

--- a/src/pages/splash/SplashLandingSection/SplashLandingSection.tsx
+++ b/src/pages/splash/SplashLandingSection/SplashLandingSection.tsx
@@ -62,7 +62,7 @@ const SplashLandingSection: FC = () => {
               eraseDelay={2000}
               showCursor
             />
-            <div className="sentence">LAUNCHPAD</div>
+            <div className="sentence">LAUNCHPAD {window.MobileContext}</div>
           </Heading>
           <SubHeading>Bring Web3 to Life</SubHeading>
         </TopContainer>


### PR DESCRIPTION
## Scope
WEB(418): Dashboard view on mobile (values for these claim forms are no longer on the screen when viewing from Mobile app).
WEB(419): Dashboard view on mobile (Tell user that they can move the map with two fingers.).
WEB(436): Remove the control panel selector and scene from mobile view.
WEB(410): Explorer - Remove all of these clickable links when user came from mobile app.

## Work Done
Fixed the scrollability of the buttons on the dashboard claim form.
Added icon to the world map to indicate that the map can be moved.
Removed control panel from mobile app view.
Removed clickable links from the explorer dashboard on mobile app view.

## Steps to Test
Navigate to the Explorer (within the app) and open a project. 
The control panel shouldn't be present - nor any option to open the control panel. 
Navigate to the dashboard and the top buttons on the claim form should be scrollable
The clickable links should be disabled.
The map should have an icon that indicates it can be moved.

## Screenshots
