### PR TITLE
Fix/web

### DIFF
--- a/configs/edheroes/config.json
+++ b/configs/edheroes/config.json
@@ -25,7 +25,7 @@
     }
   },
   "route": {
-    "splashIsRootRoute": true
+    "splashIsRootRoute": false
   },
   "Project": {
     "title": "Project",

--- a/configs/idcc/config.json
+++ b/configs/idcc/config.json
@@ -26,7 +26,7 @@
     }
   },
   "route": {
-    "splashIsRootRoute": true
+    "splashIsRootRoute": false
   },
   "Project": {
     "title": "Project",

--- a/src/pages/splash/SplashLandingSection/SplashLandingSection.tsx
+++ b/src/pages/splash/SplashLandingSection/SplashLandingSection.tsx
@@ -64,7 +64,9 @@ const SplashLandingSection: FC = () => {
             />
             <div className="sentence">LAUNCHPAD</div>
           </Heading>
-          <SubHeading>Bring Web3 to Life</SubHeading>
+          <SubHeading>
+            Bring the Internet of Impact to <strong>Life</strong>
+          </SubHeading>
         </TopContainer>
         <BottomContainer>
           <GradientButton
@@ -76,7 +78,7 @@ const SplashLandingSection: FC = () => {
           </GradientButton>
           <div>
             <AppLabel>
-              Get your <strong>Impact Wallet</strong>
+              Get your <strong>Impact X</strong> Wallet
               {'   '}
               <small>(coming soon)</small>
             </AppLabel>


### PR DESCRIPTION
## Scope
WEB(464): Launchpad splash page wording changes
WEB(465): idcc.ixo. earth must not have the launchpad splashpage

## Work Done
Updated wording on Splash page
Updating configs to only show splash page on the launchpad

## Steps to Test
Go to splash page and check wording

## Screenshots
