### PR TITLE
hiding Create feature from mobile web view

### DIFF
--- a/src/components/Entities/CreateEntity/Components/CreateEntityDropdown/CreateEntityDropdown.tsx
+++ b/src/components/Entities/CreateEntity/Components/CreateEntityDropdown/CreateEntityDropdown.tsx
@@ -27,6 +27,10 @@ const CreateEntityDropDown: React.FunctionComponent<Props> = ({ entityType }) =>
   const [isModalOpen, setIsModalOpen] = React.useState(false)
 
   const isVisible = React.useMemo(() => {
+    const isViewedFromApp = !!window.MobileContext
+    if (isViewedFromApp) {
+      return false
+    }
     if (!entityTypeMap) {
       return false
     }


### PR DESCRIPTION
## Scope
WEB-481: Users should not be able to see the Create feature in the menu when coming from the mobile web view.

## Work Done
Added logic to hide the 'Create' button when viewing the web app from the mobile app

## Steps to Test
Open web view in mobile app (after deployed) and ensure 'Create' button isn't present

## Screenshots
