### PR TITLE
Fix/verified entities on explore page

### DIFF
--- a/src/graphql/queries/entities.graphql
+++ b/src/graphql/queries/entities.graphql
@@ -3,9 +3,9 @@ query entities($relayerNode: String!, $owner: String) {
     filter: {
       not: { type: { startsWith: "asset" } }
       or: [
-        { relayerNode: { equalTo: $relayerNode } }
-        { id: { equalTo: $relayerNode } }
-        { owner: { equalTo: $owner } }
+        { and: [{ relayerNode: { equalTo: $relayerNode } }, { entityVerified: { equalTo: true } }] }
+        { and: [{ id: { equalTo: $relayerNode } }, { entityVerified: { equalTo: true } }] }
+        { and: [{ entityVerified: { equalTo: false } }, { owner: { equalTo: $owner } }] }
       ]
     }
   ) {

--- a/src/pages/EntitiesExplorer/EntitiesExplorer.container.tsx
+++ b/src/pages/EntitiesExplorer/EntitiesExplorer.container.tsx
@@ -68,7 +68,7 @@ const EntitiesExplorer: React.FunctionComponent<Props> = (props) => {
   const { getQuery } = useQuery()
   const type: string | undefined = getQuery('type')
   const sector: string | undefined = getQuery('sector')
-  const itemsCount = 6
+  const itemsCount = 10
   const [scrollOffset, setScrollOffest] = useState(1)
   const entities = React.useMemo(
     () => props.entities.slice(0, scrollOffset * itemsCount),


### PR DESCRIPTION
Fixed the query filter on entities query to return only verified entities unless the person querying is the owner of an unverified entity
