### PR TITLE
chore: use rpc endpoint to determine chain network

### DIFF
--- a/src/constants/contracts.ts
+++ b/src/constants/contracts.ts
@@ -3,15 +3,26 @@ import { ChainNetwork } from '@ixo/impactxclient-sdk/types/custom_queries/chain.
 
 type Environment = 'development' | 'testing' | 'production'
 
-function getMulticallAddress(env: Environment): string {
-  // Map the environment to the respective property name
+function getEnvironmentFromRPCURL(rpcUrl: string | undefined): Environment {
+  if (rpcUrl?.includes('devnet')) {
+    return 'development'
+  } else if (rpcUrl?.includes('testnet')) {
+    return 'testing'
+  } else if (rpcUrl?.includes('impacthub')) {
+    return 'production'
+  }
+  throw new Error('Invalid RPC URL')
+}
+
+function getMulticallAddress(rpcUrl?: string): string {
+  const env = getEnvironmentFromRPCURL(rpcUrl)
+
   const envMap: Record<Environment, ChainNetwork> = {
     development: 'devnet',
     testing: 'testnet',
     production: 'mainnet',
   }
 
-  // Find the multicall contract
   const multicallContract = customQueries.contract.getContractAddress(envMap[env], 'multicall')
 
   return multicallContract.length > 0
@@ -19,4 +30,4 @@ function getMulticallAddress(env: Environment): string {
     : 'ixo1rrra808ggl30g27zdmp9ecc00u7le2tn5gunv86p8aa99jrc84qqk8dttm'
 }
 
-export const MULTI_CALL_CONTRACT_ADDRESS = getMulticallAddress(process.env.NODE_ENV as Environment)
+export const MULTI_CALL_CONTRACT_ADDRESS = getMulticallAddress(process.env.REACT_APP_RPC_URL)


### PR DESCRIPTION
Use RPC endpoint to determine the chain network we're on, to use the correct multi contract call address