### PR TITLE
chore: add entity category to prefill type on tag creation

### DIFF
--- a/apps/web/src/pages/CreateEntity/EntityPages/SetupProperties/SetupProperties.tsx
+++ b/apps/web/src/pages/CreateEntity/EntityPages/SetupProperties/SetupProperties.tsx
@@ -72,6 +72,11 @@ const SetupProperties: React.FC = (): JSX.Element => {
             readonly: true,
           },
           {
+            category: 'Type',
+            tags: [profile?.category || ''],
+            readonly: true,
+          },
+          {
             category: 'Token Class',
             tags: ['Unspecified'],
             readonly: true,


### PR DESCRIPTION
chore: add entity category to prefill type on tag creation