### PR TITLE
chore: pull survey from protocol

### DIFF
--- a/apps/web/src/components/ServicesInitialisation/ServicesInitialisation.tsx
+++ b/apps/web/src/components/ServicesInitialisation/ServicesInitialisation.tsx
@@ -1,5 +1,5 @@
 import AccountUpdateService from 'optimized/services/account'
-import EntityUpdateService from './entity'
+// import EntityUpdateService from './entity'
 import SiteService from './site'
 import ConfigService from './config'
 
@@ -7,7 +7,7 @@ export const ServicesInitialisation = (): JSX.Element => {
   return (
     <>
       <AccountUpdateService />
-      <EntityUpdateService />
+      {/* <EntityUpdateService /> */}
       <SiteService />
       <ConfigService />
     </>

--- a/apps/web/src/graphql/queries/claimCollection.graphql
+++ b/apps/web/src/graphql/queries/claimCollection.graphql
@@ -1,0 +1,21 @@
+query ClaimCollection($claimCollectionId: String!) {
+  claimCollection(id: $claimCollectionId) {
+    nodeId
+    id
+    entity
+    admin
+    protocol
+    startDate
+    endDate
+    quota
+    count
+    evaluated
+    approved
+    rejected
+    disputed
+    invalidated
+    state
+    payments
+    claimSchemaTypesLoaded
+  }
+}

--- a/apps/web/src/hooks/claims/useSurveyTemplate.ts
+++ b/apps/web/src/hooks/claims/useSurveyTemplate.ts
@@ -1,0 +1,33 @@
+import { LinkedResource } from '@ixo/impactxclient-sdk/types/codegen/ixo/iid/v1beta1/types'
+import { useClaimCollectionQuery, useEntityLazyQuery } from 'generated/graphql'
+import { useEffect, useState } from 'react'
+import { getSurveyJsResource } from 'services'
+
+export const useSurveyTemplate = ({ claimCollectionId }: { claimCollectionId: string }) => {
+  const [surveyTemplate, setSurveyTemplate] = useState<any>(undefined)
+
+  const { data: collection } = useClaimCollectionQuery({
+    variables: {
+      claimCollectionId,
+    },
+  })
+
+  const [getProtocol] = useEntityLazyQuery()
+
+  useEffect(() => {
+    if (collection?.claimCollection?.protocol) {
+      getProtocol({ variables: { id: collection?.claimCollection?.protocol } }).then(({ data }) => {
+        const survey = data?.entity?.linkedResource.find(
+          (resource: LinkedResource) => resource.type === 'surveyTemplate',
+        )
+        if (survey) {
+          getSurveyJsResource({ resource: survey, service: data?.entity?.service }).then((response) => {
+            setSurveyTemplate(response)
+          })
+        }
+      })
+    }
+  }, [collection, getProtocol])
+
+  return surveyTemplate
+}

--- a/apps/web/src/hooks/claims/useSurveyTemplate.ts
+++ b/apps/web/src/hooks/claims/useSurveyTemplate.ts
@@ -5,6 +5,7 @@ import { getSurveyJsResource } from 'services'
 
 export const useSurveyTemplate = ({ claimCollectionId }: { claimCollectionId: string }) => {
   const [surveyTemplate, setSurveyTemplate] = useState<any>(undefined)
+  const [surveyError, setSurveyError] = useState<any>(undefined)
 
   const { data: collection } = useClaimCollectionQuery({
     variables: {
@@ -23,11 +24,11 @@ export const useSurveyTemplate = ({ claimCollectionId }: { claimCollectionId: st
         if (survey) {
           getSurveyJsResource({ resource: survey, service: data?.entity?.service }).then((response) => {
             setSurveyTemplate(response)
-          })
+          }).catch((error) => setSurveyError(error))
         }
-      })
+      }).catch((error) => setSurveyError(error))
     }
   }, [collection, getProtocol])
 
-  return surveyTemplate
+  return {surveyTemplate, surveyError }
 }

--- a/apps/web/src/pages/CurrentEntity/Overview/OfferForm/index.tsx
+++ b/apps/web/src/pages/CurrentEntity/Overview/OfferForm/index.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useMemo } from 'react'
 import { Model } from 'survey-core'
 import { Survey } from 'survey-react-ui'
 import { themeJson } from 'styles/surveyTheme'
-import { useGetOfferFormByClaimCollectionId } from 'graphql/entities'
 import { errorToast, successToast } from 'utils/toast'
 import { CellnodePublicResource } from '@ixo/impactxclient-sdk/types/custom_queries/cellnode'
 import { customQueries, ixo } from '@ixo/impactxclient-sdk'
@@ -16,6 +15,7 @@ import { AgentRoles } from 'types/models'
 import { useWallet } from '@ixo-webclient/wallet-connector'
 import { GetAddLinkedResourcePayload } from 'lib/protocol'
 import { DeliverTxResponse } from '@cosmjs/stargate'
+import { useSurveyTemplate } from 'hooks/claims/useSurveyTemplate'
 
 interface Props {
   claimCollectionId: string
@@ -24,7 +24,7 @@ interface Props {
 
 const OfferForm: React.FC<Props> = ({ claimCollectionId, agentRole }) => {
   const { signer } = useAccount()
-  const offerQuestionForm = useGetOfferFormByClaimCollectionId(claimCollectionId)
+  const offerQuestionForm = useSurveyTemplate({ claimCollectionId })
   const { data: iid } = useGetIid(signer.did)
   const offerSent = useMemo(() => {
     const linkedResource: LinkedResource[] = iid?.linkedResource ?? []

--- a/apps/web/src/pages/CurrentEntity/Overview/OfferForm/index.tsx
+++ b/apps/web/src/pages/CurrentEntity/Overview/OfferForm/index.tsx
@@ -24,7 +24,7 @@ interface Props {
 
 const OfferForm: React.FC<Props> = ({ claimCollectionId, agentRole }) => {
   const { signer } = useAccount()
-  const offerQuestionForm = useSurveyTemplate({ claimCollectionId })
+  const { surveyTemplate: offerQuestionForm } = useSurveyTemplate({ claimCollectionId })
   const { data: iid } = useGetIid(signer.did)
   const offerSent = useMemo(() => {
     const linkedResource: LinkedResource[] = iid?.linkedResource ?? []
@@ -60,7 +60,10 @@ const OfferForm: React.FC<Props> = ({ claimCollectionId, agentRole }) => {
         })
         const addLinkedResourcePayload = GetAddLinkedResourcePayload(signer.did, signer, linkedResource)
 
-        const response = (await execute({ data: addLinkedResourcePayload as any, transactionConfig: { sequence: 1 }})) as unknown as DeliverTxResponse
+        const response = (await execute({
+          data: addLinkedResourcePayload as any,
+          transactionConfig: { sequence: 1 },
+        })) as unknown as DeliverTxResponse
 
         if (response.code === 0) {
           close()


### PR DESCRIPTION
## Scope
Display form for application of oracle or agent, independent of all entity being loaded
## Work Done
Refactored current solution that depended on all protocols being in state to find the protocol entity linked to the collection. Solution: to get protocol id from claim collection selected and fetch protocol from blocksync and fetch template from storage 
## Steps to Test
Navigate to claim and apply as agent or oracle service
## Screenshots
![Screenshot from 2024-07-08 02-58-01](https://github.com/ixofoundation/ixo-webclient/assets/141128405/7f426fcc-7c10-429b-84d0-f3d5bd28f919)
