### PR TITLE
refactor: Extract getLinkedResourceTypeFromPrefix function

### DIFF
--- a/apps/web/src/components/Modals/ProposalActionModal/ProposalActionModal.tsx
+++ b/apps/web/src/components/Modals/ProposalActionModal/ProposalActionModal.tsx
@@ -11,6 +11,7 @@ import { customQueries, utils } from '@ixo/impactxclient-sdk'
 import { chainNetwork } from 'hooks/configs'
 import { LinkedResource } from '@ixo/impactxclient-sdk/types/codegen/ixo/iid/v1beta1/types'
 import { ProposalActionConfigMap } from 'constants/entity'
+import { getLinkedResourceTypeFromPrefix } from 'utils/common'
 
 interface Props {
   linkedResource: LinkedResource
@@ -19,7 +20,16 @@ interface Props {
   onChange?: (linkedResource: LinkedResource) => void
 }
 
-const ProposalActionModal: React.FC<Props> = ({ linkedResource, open, onClose, onChange }): JSX.Element => {
+const ProposalActionModal: React.FC<Props> = ({
+  linkedResource: _linkedResource,
+  open,
+  onClose,
+  onChange,
+}): JSX.Element => {
+  const linkedResource = {
+    ..._linkedResource,
+    type: getLinkedResourceTypeFromPrefix(_linkedResource.type),
+  }
   const [type, setType] = useState<string>('')
   const [uploading, setUploading] = useState(false)
   const options = useMemo(

--- a/apps/web/src/hooks/editEntity.ts
+++ b/apps/web/src/hooks/editEntity.ts
@@ -1,15 +1,17 @@
 import { EncodeObject } from '@cosmjs/proto-signing'
+import { ixo, utils } from '@ixo/impactxclient-sdk'
+import { DeliverTxResponse } from '@ixo/impactxclient-sdk/node_modules/@cosmjs/stargate'
 import {
-  Service,
   LinkedEntity,
   LinkedResource,
+  Service,
   VerificationMethod,
 } from '@ixo/impactxclient-sdk/types/codegen/ixo/iid/v1beta1/types'
 import BigNumber from 'bignumber.js'
+import { EntityLinkedResourceConfig } from 'constants/entity'
 import {
   AddService,
   DeleteService,
-  fee,
   GetAddLinkedClaimMsgs,
   GetAddLinkedEntityMsgs,
   GetAddLinkedResourceMsgs,
@@ -21,20 +23,20 @@ import {
   GetReplaceLinkedResourceMsgs,
   GetUpdateStartAndEndDateMsgs,
   TSigner,
+  fee,
 } from 'lib/protocol'
-import { setEditedFieldAction, setEditEntityAction } from 'redux/editEntity/editEntity.actions'
+import { useMemo } from 'react'
+import { useParams } from 'react-router-dom'
+import { setEditEntityAction, setEditedFieldAction } from 'redux/editEntity/editEntity.actions'
 import { selectEditEntity } from 'redux/editEntity/editEntity.selectors'
-import { useAppDispatch, useAppSelector } from 'redux/hooks'
-import { LinkedResourceProofGenerator, LinkedResourceServiceEndpointGenerator } from 'utils/entities'
-import { DeliverTxResponse } from '@ixo/impactxclient-sdk/node_modules/@cosmjs/stargate'
-import { ixo, utils } from '@ixo/impactxclient-sdk'
-import { NodeType, TDAOGroupModel, TEntityModel, TEntityPageModel } from 'types/entities'
-import { EntityLinkedResourceConfig } from 'constants/entity'
 import { getEntityById, selectAllClaimProtocols } from 'redux/entities/entities.selectors'
+import { useAppDispatch, useAppSelector } from 'redux/hooks'
+import { NodeType, TDAOGroupModel, TEntityModel, TEntityPageModel } from 'types/entities'
+import { LINKED_RESOURCE_TYPES_PREFIX, getLinkedResourceTypeFromPrefix } from 'utils/common'
+import { LinkedResourceProofGenerator, LinkedResourceServiceEndpointGenerator } from 'utils/entities'
+import { v4 as uuidv4 } from 'uuid'
 import { useWallet } from 'wallet-connector'
 import { useService } from './service'
-import { v4 as uuidv4 } from 'uuid'
-import { useParams } from 'react-router-dom'
 
 export default function useEditEntity(): {
   editEntity: TEntityModel
@@ -46,7 +48,18 @@ export default function useEditEntity(): {
   const { execute, wallet } = useWallet()
   const { entityId = '' } = useParams<{ entityId: string }>()
 
-  const editEntity: TEntityModel = useAppSelector(selectEditEntity)
+  const _editEntity = useAppSelector(selectEditEntity)
+  const editEntity = useMemo(() => {
+    return {
+      ..._editEntity,
+      linkedResource: _editEntity?.linkedResource?.map((item) => ({
+        ...item,
+        display: item?.display ?? item?.type?.startsWith(LINKED_RESOURCE_TYPES_PREFIX),
+        type: getLinkedResourceTypeFromPrefix(item?.type),
+      })),
+    }
+  }, [_editEntity])
+
   const currentEntity = useAppSelector(getEntityById(entityId))
   const claimProtocols = useAppSelector(selectAllClaimProtocols)
   const services: Service[] = currentEntity.service
@@ -339,11 +352,17 @@ export default function useEditEntity(): {
   }
 
   const getEditedLinkedFilesMsgs = async (): Promise<readonly EncodeObject[]> => {
-    const editedLinkedFiles = editEntity.linkedResource.filter((item: LinkedResource) =>
-      Object.keys(EntityLinkedResourceConfig).includes(item.type),
-    )
+    
+    const editedLinkedFiles = editEntity.linkedResource.reduce((acc: LinkedResource[], cur: LinkedResource) => {
+      if (Object.keys(EntityLinkedResourceConfig).includes(cur.type)) {
+        cur.type = cur.display ? `${LINKED_RESOURCE_TYPES_PREFIX}${cur.type}` : cur.type
+        // delete cur.display
+        acc.push(cur)
+      }
+      return acc
+    }, [])
     const currentLinkedFiles = currentEntity.linkedResource.filter((item: LinkedResource) =>
-      Object.keys(EntityLinkedResourceConfig).includes(item.type),
+      Object.keys(EntityLinkedResourceConfig).includes(getLinkedResourceTypeFromPrefix(item.type)),
     )
     if (JSON.stringify(editedLinkedFiles) === JSON.stringify(currentLinkedFiles)) {
       return []
@@ -362,22 +381,27 @@ export default function useEditEntity(): {
         .filter((item: LinkedResource) => !editedLinkedFiles.some((v) => v.id === item.id)),
     ]
 
-    const messages: readonly EncodeObject[] = diffLinkedFiles.reduce(
-      (acc: EncodeObject[], cur: LinkedResource) => [
-        ...acc,
-        ...(currentLinkedFiles.some((item: LinkedResource) => item.id === cur.id)
-          ? editedLinkedFiles.some((item: LinkedResource) => item.id === cur.id)
-            ? GetReplaceLinkedResourceMsgs(
-                editEntity.id,
-                signer,
-                cur,
-                editEntity?.linkedResource?.find((v) => v.id === cur.id),
-              )
-            : GetDeleteLinkedResourceMsgs(editEntity.id, signer, cur)
-          : GetAddLinkedResourceMsgs(editEntity.id, signer, cur)),
-      ],
-      [],
-    )
+    const messages: readonly EncodeObject[] = diffLinkedFiles.reduce((acc: EncodeObject[], cur: LinkedResource) => {
+      const isInCurrent = currentLinkedFiles.some((item: LinkedResource) => item.id === cur.id)
+      const isInEdited = editedLinkedFiles.some((item: LinkedResource) => item.id === cur.id)
+
+      if (isInCurrent) {
+        // If the resource is in both current and edited, replace it.
+        if (isInEdited) {
+          const editedResource = editEntity.linkedResource.find((v) => v.id === cur.id)
+          const message = GetReplaceLinkedResourceMsgs(editEntity.id, signer, cur, editedResource)
+          return [...acc, ...message]
+        } else {
+          // If it's in current but not in edited, delete it.
+          const message = GetDeleteLinkedResourceMsgs(editEntity.id, signer, cur)
+          return [...acc, ...message]
+        }
+      } else {
+        // If it's not in current, it's a new resource, so add it.
+        const message = GetAddLinkedResourceMsgs(editEntity.id, signer, cur)
+        return [...acc, ...message]
+      }
+    }, [])
 
     return messages
   }

--- a/apps/web/src/lib/protocol/entity.ts
+++ b/apps/web/src/lib/protocol/entity.ts
@@ -1,4 +1,5 @@
-import { ixo, customMessages, utils } from '@ixo/impactxclient-sdk'
+import { EncodeObject } from '@cosmjs/proto-signing'
+import { customMessages, ixo, utils } from '@ixo/impactxclient-sdk'
 import {
   QueryEntityIidDocumentRequest,
   QueryEntityListRequest,
@@ -6,21 +7,20 @@ import {
   QueryEntityRequest,
   QueryEntityResponse,
 } from '@ixo/impactxclient-sdk/types/codegen/ixo/entity/v1beta1/query'
+import { MsgTransferEntity, MsgUpdateEntity } from '@ixo/impactxclient-sdk/types/codegen/ixo/entity/v1beta1/tx'
 import { IidDocument } from '@ixo/impactxclient-sdk/types/codegen/ixo/iid/v1beta1/iid'
+import { Verification } from '@ixo/impactxclient-sdk/types/codegen/ixo/iid/v1beta1/tx'
 import {
   AccordedRight,
+  Context,
+  LinkedClaim,
   LinkedEntity,
   LinkedResource,
   Service,
-  Context,
-  LinkedClaim,
 } from '@ixo/impactxclient-sdk/types/codegen/ixo/iid/v1beta1/types'
 import BigNumber from 'bignumber.js'
-import { fee, RPC_ENDPOINT, TSigner } from './common'
-import { Verification } from '@ixo/impactxclient-sdk/types/codegen/ixo/iid/v1beta1/tx'
-import { EncodeObject } from '@cosmjs/proto-signing'
-import { MsgTransferEntity, MsgUpdateEntity } from '@ixo/impactxclient-sdk/types/codegen/ixo/entity/v1beta1/tx'
 import { hexToUint8Array } from 'utils/encoding'
+import { RPC_ENDPOINT, TSigner, fee } from './common'
 
 const createRPCQueryClient = ixo.ClientFactory.createRPCQueryClient
 
@@ -85,7 +85,10 @@ export const CreateEntityMessage = async (
         ownerAddress: ownerAddress,
         relayerNode: relayerNode,
         service: service.map((item: Service) => ixo.iid.v1beta1.Service.fromPartial(item)),
-        linkedResource: linkedResource.map((item: LinkedResource) => ixo.iid.v1beta1.LinkedResource.fromPartial(item)),
+        linkedResource: linkedResource.map((item: LinkedResource) => {
+          item.type = item?.display ? `display:${item.type}` : item.type
+          return ixo.iid.v1beta1.LinkedResource.fromPartial(item)
+        }),
         accordedRight: accordedRight.map((item: AccordedRight) => ixo.iid.v1beta1.AccordedRight.fromPartial(item)),
         linkedEntity: linkedEntity.map((item: LinkedEntity) => ixo.iid.v1beta1.LinkedEntity.fromPartial(item)),
         linkedClaim: linkedClaim.map((item: LinkedClaim) => ixo.iid.v1beta1.LinkedClaim.fromPartial(item)),

--- a/apps/web/src/screens/CreateEntity/Forms/PropertiesForm/PropertiesForm.tsx
+++ b/apps/web/src/screens/CreateEntity/Forms/PropertiesForm/PropertiesForm.tsx
@@ -114,7 +114,6 @@ const PropertiesForm: React.FC<Props> = ({
     accordedRight,
     updateAccordedRight,
   }
-  console.log("🚀 ~ AccordedRightProps.accordedRight:", AccordedRightProps.accordedRight)
 
   const LinkedEntityProps = {
     linkedEntity,

--- a/apps/web/src/screens/CreateEntity/Forms/PropertiesForm/SetupAccordedRight/SetupAccordedRight.tsx
+++ b/apps/web/src/screens/CreateEntity/Forms/PropertiesForm/SetupAccordedRight/SetupAccordedRight.tsx
@@ -16,7 +16,6 @@ interface Props {
 }
 
 const SetupAccordedRight: React.FC<Props> = ({ hidden, accordedRight, updateAccordedRight }): JSX.Element => {
-  console.log('🚀 ~ accordedRight:', accordedRight)
   const [openAddAccordedRightModal, setOpenAddAccordedRightModal] = useState(false)
   const [openAddAccordedRightDetailsModalKey, setOpenAddAccordedRightDetailsModalKey] = useState<string | null>(null)
 

--- a/apps/web/src/screens/CreateEntity/Forms/PropertiesForm/SetupLinkedResource/SetupLinkedResource.tsx
+++ b/apps/web/src/screens/CreateEntity/Forms/PropertiesForm/SetupLinkedResource/SetupLinkedResource.tsx
@@ -9,6 +9,7 @@ import { LinkedResource } from '@ixo/impactxclient-sdk/types/codegen/ixo/iid/v1b
 import { omitKey } from 'utils/objects'
 import { EntityLinkedResourceConfig } from 'constants/entity'
 import ProposalActionModal from 'components/Modals/ProposalActionModal/ProposalActionModal'
+import { getLinkedResourceTypeFromPrefix } from 'utils/common'
 
 const initialLinkedResource = {
   id: '',
@@ -51,6 +52,8 @@ const SetupLinkedResource: React.FC<Props> = ({ hidden, linkedResource, updateLi
     updateLinkedResource(omitKey({ ...linkedResource }, id))
   }
 
+
+
   return (
     <>
       <FlexBox $direction='column' style={hidden ? { display: 'none' } : {}}>
@@ -58,8 +61,9 @@ const SetupLinkedResource: React.FC<Props> = ({ hidden, linkedResource, updateLi
           {Object.entries(linkedResource)
             .filter(([key, value]) => value)
             .map(([key, value]) => {
-              const Icon = EntityLinkedResourceConfig[value?.type || '']?.icon
-              const label = EntityLinkedResourceConfig[value?.type || '']?.text || value?.type
+              const entityType = getLinkedResourceTypeFromPrefix(value.type)
+              const Icon = EntityLinkedResourceConfig[entityType]?.icon
+              const label = EntityLinkedResourceConfig[entityType]?.text || entityType
 
               return (
                 <PropertyBox
@@ -85,18 +89,20 @@ const SetupLinkedResource: React.FC<Props> = ({ hidden, linkedResource, updateLi
         onAdd={handleAddLinkedResource}
       />
 
-      {selectedId && !!linkedResource[selectedId] && linkedResource[selectedId].type !== 'proposalAction' && (
-        <LinkedResourceSetupModal
-          linkedResource={linkedResource[selectedId] as any}
-          open={!!selectedId}
-          onClose={(): void => setSelectedId('')}
-          onChange={(linkedResource: LinkedResource): void => handleUpdateLinkedResource(selectedId, linkedResource)}
-        />
-      )}
+      {selectedId &&
+        !!linkedResource[selectedId] &&
+        getLinkedResourceTypeFromPrefix(linkedResource[selectedId].type) !== 'proposalAction' && (
+          <LinkedResourceSetupModal
+            linkedResource={linkedResource[selectedId] as any}
+            open={!!selectedId}
+            onClose={(): void => setSelectedId('')}
+            onChange={(linkedResource: LinkedResource): void => handleUpdateLinkedResource(selectedId, linkedResource)}
+          />
+        )}
       {selectedId &&
         !!linkedResource[selectedId] &&
         !linkedResource[selectedId].serviceEndpoint &&
-        linkedResource[selectedId].type === 'proposalAction' && (
+        getLinkedResourceTypeFromPrefix(linkedResource[selectedId].type) === 'proposalAction' && (
           <ProposalActionModal
             linkedResource={linkedResource[selectedId] as any}
             open={!!selectedId}

--- a/apps/web/src/utils/common.ts
+++ b/apps/web/src/utils/common.ts
@@ -23,3 +23,8 @@ export function findKeyValuePairs(obj: Record<string, any>, propertyName: string
   });
   return result;
 }
+
+export const LINKED_RESOURCE_TYPES_PREFIX = "display:";
+export function getLinkedResourceTypeFromPrefix(linkedResourceType: string): string {
+  return linkedResourceType.replace(LINKED_RESOURCE_TYPES_PREFIX, '')
+}

--- a/apps/web/src/utils/dao/getDaoContractInfo.ts
+++ b/apps/web/src/utils/dao/getDaoContractInfo.ts
@@ -1,4 +1,4 @@
-import { CosmWasmClient } from '@ixo/impactxclient-sdk/node_modules/@cosmjs/cosmwasm-stargate'
+import { CosmWasmClient } from '@cosmjs/cosmwasm-stargate'
 import { ProposalResponse, VoteInfo } from '@ixo/impactxclient-sdk/types/codegen/DaoProposalSingle.types'
 
 import { durationToSeconds, expirationAtTimeToSecondsFromNow } from 'utils/conversions'


### PR DESCRIPTION
- Extracted the getLinkedResourceTypeFromPrefix function from the common.ts file to its own separate function.
- This function is responsible for removing the "display:" prefix from the linkedResourceType string.

## Scope

## Work Done

## Steps to Test

## Screenshots
